### PR TITLE
Dt/local server stop

### DIFF
--- a/lib/cheffish/recipe_dsl.rb
+++ b/lib/cheffish/recipe_dsl.rb
@@ -96,9 +96,15 @@ class Chef
     end
 
     def self.stop_local_servers
+      # Just in case we're running this out of order:
+      @@local_servers ||= []
+
+      # Stop the servers
       @@local_servers.each do |server|
         server.stop
       end
+
+      # Clean up after ourselves (don't want to stop a server twice)
       @@local_servers = []
     end
   end


### PR DESCRIPTION
Added class method to stop the servers started by the DSL; this is needed to cleanse the palate before restarting servers for the next chef metal run when running multiple recipes/platforms in Test Kitchen.
