### PR TITLE
Fix problem when setting public key from String.

### DIFF
--- a/lib/cheffish/actor_provider_base.rb
+++ b/lib/cheffish/actor_provider_base.rb
@@ -74,7 +74,13 @@ class Cheffish::ActorProviderBase < Cheffish::ChefProviderBase
     @new_public_key ||= begin
       if new_resource.source_key
         if new_resource.source_key.is_a?(String)
-          Cheffish::KeyFormatter.decode(new_resource.source_key)
+          key, key_format = Cheffish::KeyFormatter.decode(new_resource.source_key)
+
+          if key.private?
+            key.public_key
+          else
+            key
+          end
         elsif new_resource.source_key.private?
           new_resource.source_key.public_key
         else


### PR DESCRIPTION
While using the chef_client resource this failed because I wasn't passing `OpenSSL::PKey::RSA` but instead a `String` as the API indicates is acceptable. The formatter returns an Array tuple which fails a little bit further down when setting the JSON (assuming for payload) using the `#to_pem` method call. 
