### PR TITLE
perform a deep merge of the current resource and new resource in new_json

### DIFF
--- a/lib/cheffish/chef_provider_base.rb
+++ b/lib/cheffish/chef_provider_base.rb
@@ -32,7 +32,7 @@ module Cheffish
           result = normalize(resource_to_json(new_resource))
         else
           # If resource is incomplete, use current json to fill any holes
-          result = current_json.merge(resource_to_json(new_resource))
+          result = Chef::Mixin::DeepMerge.hash_only_merge(current_json, resource_to_json(new_resource))
         end
         augment_new_json(result)
       end

--- a/spec/integration/chef_node_spec.rb
+++ b/spec/integration/chef_node_spec.rb
@@ -129,6 +129,34 @@ describe Chef::Resource::ChefNode do
         end
       end
 
+      context 'with chef_node "blah" and an updated normal attribute value' do
+        with_converge do
+          chef_node 'blah' do
+            attributes 'foo' => 'fum'
+          end
+        end
+
+        it 'new normal attribute is added' do
+          expect(chef_run).to have_updated 'chef_node[blah]', :create
+          node = get('nodes/blah')
+          expect(node['normal']).to eq({ 'foo' => 'fum', 'tags' => [ 'a', 'b' ] })
+        end
+      end
+
+      context 'with chef_node "blah" and a new normal attribute' do
+        with_converge do
+          chef_node 'blah' do
+            attributes 'foe' => 'fum'
+          end
+        end
+
+        it 'new normal attribute is added' do
+          expect(chef_run).to have_updated 'chef_node[blah]', :create
+          node = get('nodes/blah')
+          expect(node['normal']).to eq({ 'foe' => 'fum', 'foo' => 'bar', 'tags' => [ 'a', 'b' ] })
+        end
+      end
+
       context 'with chef_node "blah" with complete true' do
         with_converge do
           chef_node 'blah' do
@@ -147,6 +175,22 @@ describe Chef::Resource::ChefNode do
           expect(node['override']).to eq({ 'foo4' => 'bar4' })
         end
       end
+
+      context 'with chef_node "blah", complete true and a new normal attribute' do
+        with_converge do
+          chef_node 'blah' do
+            attributes 'foe' => 'fum'
+            complete true
+          end
+        end
+
+        it 'normal foo attribute is replaced with new attribute' do
+          expect(chef_run).to have_updated 'chef_node[blah]', :create
+          node = get('nodes/blah')
+          expect(node['normal']).to eq({ 'foe' => 'fum', 'tags' => [ 'a', 'b' ] })
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
My team recently noticed attribute attributes disappearing when reconverging machines. It looks as though the machine resource is dropping attributes in the merge of the current node resource and the new one. I have added a deep merge which appears to fix this. Here is an example before after:

Current:

```
{"name"=>"MWDLABFTP01", "json_class"=>"Chef::Node", "chef_type"=>"node", "chef_environment"=>"mw", "override"=>{"datacenter"=>"QA1", "test_value"=>"test_from_file", "platform_haproxy"=>{"include_newrelic"=>false}, "platform_rabbitmq"=>{"include_newrelic"=>false}, "provisioner"=>{"use_linked_clone"=>true, "client_run_interval"=>0, "test_chef_server_host"=>"172.21.20.31", "cluster"=>{"TESTUBU"=>{"ip_start"=>61}, "TWN"=>{"ip_start"=>62}, "haproxy"=>{"ip_start"=>33}, "rabbit"=>{"ip_start"=>35}, "web"=>{"ip_start"=>38}, "mt"=>{"ip_start"=>60}, "ovf"=>{"ip_start"=>40}, "search"=>{"ip_start"=>63}, "couch"=>{"ip_start"=>66}}}, "platform_octopus"=>{"server_uri"=>""}, "environment_parent"=>"QA"}, "normal"=>{"blah"=>"blah", "chef_client"=>{"interval"=>0}, "tags"=>nil, "metal"=>{"location"=>{"driver_url"=>"vsphere://172.21.10.10/sdk?use_ssl=true&insecure=true", "driver_version"=>"0.3.50", "server_id"=>"5006e1bf-ae27-6f65-4500-8a466df375a8", "is_windows"=>true, "allocated_at"=>"2014-09-05 00:55:15 UTC", "key_name"=>"metal_default"}}}}
```

New:

```
{"name"=>"MWDLABFTP01", "chef_environment"=>"mw", "normal"=>{"chef_client"=>{"interval"=>0}}}
```

In the current code the Normal Blah attribute is dropped.

This looks ok to me but maybe there are scenarios that I may not be considering.
