### PR TITLE
Fix ChefMirror referencing chef_server :client_key

### DIFF
--- a/lib/chef/provider/chef_mirror.rb
+++ b/lib/chef/provider/chef_mirror.rb
@@ -108,7 +108,7 @@ class Chef::Provider::ChefMirror < Chef::Provider::LWRPBase
     config = {
       :chef_server_url => new_resource.chef_server[:chef_server_url],
       :node_name => new_resource.chef_server[:options][:client_name],
-      :client_key => new_resource.chef_server[:options][:client_key],
+      :client_key => new_resource.chef_server[:options][:signing_key_filename],
       :repo_mode => repo_mode,
       :versioned_cookbooks => Chef::Config.versioned_cookbooks
     }


### PR DESCRIPTION
I have been poking around with both of these LWRPs and found a few issues. 

The first is that `ChefResolvedCookbooks` was not added to the recipe_dsl.rb file and thus not available unless you explicitly require it. And the second is that `:client_key` is used to reference `chef_server` hash in mirror when we've used `:signing_key_filename` everywhere else!
