### PR TITLE
Add user full name to chef_user

### DIFF
--- a/lib/chef/provider/chef_user.rb
+++ b/lib/chef/provider/chef_user.rb
@@ -41,6 +41,7 @@ class Chef::Provider::ChefUser < Cheffish::ActorProviderBase
     {
       'name' => :name,
       'username' => :name,
+      'display_name' => :display_name,
       'admin' => :admin,
       'email' => :email,
       'password' => :password,

--- a/lib/chef/resource/chef_user.rb
+++ b/lib/chef/resource/chef_user.rb
@@ -15,6 +15,7 @@ class Chef::Resource::ChefUser < Chef::Resource::LWRPBase
 
   # Client attributes
   attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+  attribute :display_name, :kind_of => String
   attribute :admin, :kind_of => [TrueClass, FalseClass]
   attribute :email, :kind_of => String
   attribute :external_authentication_uid


### PR DESCRIPTION
Chef Server 12 requires user full name string as an input to the user endpoint.
