### PR TITLE
fixing undefined local variable or method block in honor_local_mode

### DIFF
--- a/lib/cheffish.rb
+++ b/lib/cheffish.rb
@@ -57,7 +57,7 @@ module Cheffish
     Cheffish.profiled_config(chef_config)
   end
 
-  def self.honor_local_mode(local_mode_default = true)
+  def self.honor_local_mode(local_mode_default = true, &block)
     if !Chef::Config.has_key?(:local_mode) && !local_mode_default.nil?
       Chef::Config.local_mode = local_mode_default
     end


### PR DESCRIPTION
After updating to the latest cheffish, we are receiving the following error from our kitchen driver that uses `honor_local_mode`:

```
[Execute platform_win:kitchen:middle-tier-windows-2012R2] Kitchen::ActionFailed: Failed to complete #create action: [undefined local variable or method `block' for Cheffish:Module]

Stacktrace:
/home/teamcity/.chefdk/gem/ruby/2.1.0/gems/cheffish-0.8.3/lib/cheffish.rb:69:in `honor_local_mode'
/home/teamcity/.chefdk/gem/ruby/2.1.0/gems/clc-chef-metal-vsphere-0.3.56/lib/kitchen/driver/vsphere.rb:55:in `with_metal_driver'
```

Adding `&block` to the parameter list to fix.
