### PR TITLE
Fix for opscode/chef-provisioning#209 normal attributes not persisting.

### DIFF
--- a/lib/cheffish/chef_provider_base.rb
+++ b/lib/cheffish/chef_provider_base.rb
@@ -32,7 +32,7 @@ module Cheffish
           result = normalize(resource_to_json(new_resource))
         else
           # If the resource is incomplete, we use the current json to fill any holes
-          result = current_json.merge(resource_to_json(new_resource))
+          result = Chef::Mixin::DeepMerge.merge(current_json, resource_to_json(new_resource))
         end
         augment_new_json(result)
       end


### PR DESCRIPTION
This patch preserves normal attributes when using chef-provisioning in local mode (chef-client -z). It breaks the unit tests for normal attributes which I left failing because I'm not sure quite how to resolve. It seems to me that the normal attributes should be deep merged when new_resource.complete is false, but I don't know enough about cheffish.