### PR TITLE
Add version constraint on chef less than 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ if RUBY_VERSION.to_f < 2.0
   gem 'openssl_pkcs8'
 end
 
-gem 'chef', ">= 11.8", :github => 'opscode/chef' #:path => '../chef'
+gem 'chef', ">= 11.8", "< 12" #:path => '../chef'
 #gem 'chef-zero', :path => '../chef-zero'


### PR DESCRIPTION
Currently there are a *lot* of breaking API changes in chef12.
This patch ensures a version of chef11 is installed.
Also, the upstream chef repo changed to Chef.  I removed the path hard git link.