### PR TITLE
Fixes ability to add user group to certain organization on chef 12 server

### DIFF
--- a/lib/chef/provider/chef_organization.rb
+++ b/lib/chef/provider/chef_organization.rb
@@ -52,9 +52,22 @@ class Chef::Provider::ChefOrganization < Cheffish::ChefProviderBase
     new_resource.members.each do |user|
       if !existing_members.include?(user)
         converge_by "Add #{user} to organization #{new_resource.name}" do
-          rest.post("#{rest.root_url}/organizations/#{new_resource.name}/users/#{user}", {})
+          add_user_to_org(user, new_resource.name)
         end
       end
+    end
+  end
+
+  def add_user_to_org(user, org)
+    response = rest.post("#{rest.root_url}/organizations/#{org}/association_requests", { 'user' => user })
+    association_id = response["uri"].split("/").last
+    rest.put("#{rest.root_url}/users/#{user}/association_requests/#{association_id}", { 'response' => 'accept' })
+  rescue Net::HTTPServerException => e
+    if e.response.code == "409"
+      rest.delete("#{rest.root_url}/organizations/#{org}/association_requests/#{outstanding_invites[user]}")
+      add_user_to_org(user, org)
+    else
+      raise
     end
   end
 


### PR DESCRIPTION
Fixes Issue #38 so the chef_group lwrp can be used to add users to certain group of an organization. User must be part of organization already so had to patch chef_organization lwrp to add all users in members attribute to organization when create action is called. Changes needed for cheffish gem to work with lastest chef 12 chef-server-core package.