### PR TITLE
Use correct user-association endpoint for Chef 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
   allow_failures:
     - env: CHEF_VERSION=master
     - env: CHEF_VERSION=12.4.1
+    - env: CHEF_VERSION=12.2.1
+    - env: CHEF_VERSION=12.1.2
 
 script:
   - bundle install --jobs=3 --retry=3

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source "https://rubygems.org"
 gemspec
 
+# TODO when chef-zero > 4.2.3 is released then just depend on that
+
+gem 'chef-zero', git: 'https://github.com/chef/chef-zero'
+
 if RUBY_VERSION.to_f < 2.0
   gem 'openssl_pkcs8'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 gemspec
 
 # TODO when chef-zero > 4.2.3 is released then just depend on that
-
-gem 'chef-zero', git: 'https://github.com/chef/chef-zero'
+gem 'chef-zero', github: 'chef/chef-zero'
+gem 'chef', '= 12.3.0'
 
 if RUBY_VERSION.to_f < 2.0
   gem 'openssl_pkcs8'

--- a/chef-client-version.gemfile
+++ b/chef-client-version.gemfile
@@ -2,6 +2,9 @@ source "https://rubygems.org"
 
 chef_version = ENV['CHEF_VERSION']
 
+# TODO when chef-zero > 4.2.3 is released then just depend on that
+gem 'chef-zero', github: 'chef/chef-zero'
+
 if chef_version == 'master'
   puts "Testing chef/chef master"
   gem 'chef', github: 'chef/chef'

--- a/lib/chef/provider/chef_organization.rb
+++ b/lib/chef/provider/chef_organization.rb
@@ -53,7 +53,7 @@ class Chef::Provider::ChefOrganization < Cheffish::ChefProviderBase
     new_resource.members.each do |user|
       if !existing_members.include?(user)
         converge_by "Add #{user} to organization #{new_resource.name}" do
-          rest.post("#{rest.root_url}/organizations/#{new_resource.name}/users/#{user}", {})
+          rest.post("#{rest.root_url}/organizations/#{new_resource.name}/users/", { 'username' => user })
         end
       end
     end

--- a/lib/chef/resource/chef_organization.rb
+++ b/lib/chef/resource/chef_organization.rb
@@ -35,10 +35,11 @@ class Chef::Resource::ChefOrganization < Chef::Resource::LWRPBase
     !!@invites
   end
 
-  # A list of users who must be members of the org.  This will use the new Chef 12
-  # POST /organizations/ORG/users/NAME endpoint to add them directly to the org.
-  # If you do not have permission to perform this operation, and the users are not
-  # a part of the org, the resource update will fail.
+  # A list of users who must be members of the org.  This will use the
+  # new Chef 12 POST /organizations/ORG/users endpoint to add them
+  # directly to the org.  If you do not have permission to perform
+  # this operation, and the users are not a part of the org, the
+  # resource update will fail.
   def members(*users)
     if users.size == 0
       @members || []

--- a/spec/integration/chef_mirror_spec.rb
+++ b/spec/integration/chef_mirror_spec.rb
@@ -160,8 +160,8 @@ describe Chef::Resource::ChefMirror do
           }.to have_updated('chef_mirror[]', :upload)
           expect { get('nodes/x') }.not_to raise_error
           expect { get('roles/x') }.not_to raise_error
-          expect { get('nodes/y') }.to raise_error
-          expect { get('roles/y') }.to raise_error
+          expect { get('nodes/y') }.to raise_error /404/
+          expect { get('roles/y') }.to raise_error /404/
         end
 
         it "Upload with chef_repo_path(:chef_repo_path) with multiple paths uploads everything" do
@@ -192,8 +192,8 @@ describe Chef::Resource::ChefMirror do
             end
           }.to have_updated('chef_mirror[]', :upload)
           expect { get('nodes/x') }.not_to raise_error
-          expect { get('roles/x') }.to raise_error
-          expect { get('nodes/y') }.to raise_error
+          expect { get('roles/x') }.to raise_error /404/
+          expect { get('nodes/y') }.to raise_error /404/
           expect { get('roles/y') }.not_to raise_error
         end
 
@@ -209,8 +209,8 @@ describe Chef::Resource::ChefMirror do
             end
           }.to have_updated('chef_mirror[]', :upload)
           expect { get('nodes/x') }.not_to raise_error
-          expect { get('roles/x') }.to raise_error
-          expect { get('nodes/y') }.to raise_error
+          expect { get('roles/x') }.to raise_error /404/
+          expect { get('nodes/y') }.to raise_error /404/
           expect { get('roles/y') }.not_to raise_error
         end
 

--- a/spec/integration/private_key_spec.rb
+++ b/spec/integration/private_key_spec.rb
@@ -297,7 +297,7 @@ describe Chef::Resource::PrivateKey do
           converge {
             private_key "#{repo_path}/blah"
           }
-        }.to raise_error
+        }.to raise_error /missing pass phrase?/
       end
     end
 

--- a/spec/integration/rspec/converge_spec.rb
+++ b/spec/integration/rspec/converge_spec.rb
@@ -108,13 +108,13 @@ describe 'Cheffish::RSpec::ChefRunSupport' do
             content 'test'
           end
         }.to be_up_to_date
-      }.to raise_error
+      }.to raise_error RSpec::Expectations::ExpectationNotMetError
     end
 
     it "expect_recipe { }.to be_updated fails" do
       expect {
         expect_recipe { }.to be_updated
-      }.to raise_error
+      }.to raise_error RSpec::Expectations::ExpectationNotMetError
     end
 
     it "expect_recipe { }.to be_up_to_date succeeds" do
@@ -157,7 +157,7 @@ describe 'Cheffish::RSpec::ChefRunSupport' do
     it "expect_converge { raise 'oh no' }.to raise_error passes" do
       expect_converge {
         raise 'oh no'
-      }.to raise_error
+      }.to raise_error('oh no')
     end
   end
 


### PR DESCRIPTION
The correct endpoint for user-association is:

POST /organizations/ORGNAME/users

The API currently being made will be rejected with a 405 Method Not
Allowed error.