### PR TITLE
avoid nilerror

### DIFF
--- a/lib/cheffish/chef_run_listener.rb
+++ b/lib/cheffish/chef_run_listener.rb
@@ -20,8 +20,10 @@ module Cheffish
 
     def disconnect
       # Stop the servers
-      node.run_context.cheffish.local_servers.each do |server|
-        server.stop
+      if node.run_context
+        node.run_context.cheffish.local_servers.each do |server|
+          server.stop
+        end
       end
     end
   end


### PR DESCRIPTION
if we throw an error early enough that we don't have a run_context
setup yet, then this error handler will get a NoMethod for nil error
which will mask the exception that chef-client threw.