### PR TITLE
Do not use Objects at value

### DIFF
--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -28,8 +28,6 @@ class Chef::Resource::ChefRole < Chef::Resource::LWRPBase
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
 
-  NOT_PASSED=Object.new
-
   # default_attribute 'ip_address', '127.0.0.1'
   # default_attribute [ 'pushy', 'port' ], '9000'
   # default_attribute 'ip_addresses' do |existing_value|
@@ -37,9 +35,9 @@ class Chef::Resource::ChefRole < Chef::Resource::LWRPBase
   # end
   # default_attribute 'ip_address', :delete
   attr_reader :default_attribute_modifiers
-  def default_attribute(attribute_path, value=NOT_PASSED, &block)
+  def default_attribute(attribute_path, value=nil, &block)
     @default_attribute_modifiers ||= []
-    if value != NOT_PASSED
+    if value
       @default_attribute_modifiers << [ attribute_path, value ]
     elsif block
       @default_attribute_modifiers << [ attribute_path, block ]
@@ -55,9 +53,9 @@ class Chef::Resource::ChefRole < Chef::Resource::LWRPBase
   # end
   # override_attribute 'ip_address', :delete
   attr_reader :override_attribute_modifiers
-  def override_attribute(attribute_path, value=NOT_PASSED, &block)
+  def override_attribute(attribute_path, value=nil, &block)
     @override_attribute_modifiers ||= []
-    if value != NOT_PASSED
+    if value
       @override_attribute_modifiers << [ attribute_path, value ]
     elsif block
       @override_attribute_modifiers << [ attribute_path, block ]


### PR DESCRIPTION
This commit is removing NOT_PASSED class variable and instead passing `nil` to the values of the `attr_reader` defined. 

This is failing on `chefdk` with chef version `chef-12.5.0`

Here the snippet of the error:
```
[1] pry(#<Chef::Recipe>)> my_role = chef_role 'salim'
=> #<Chef::Resource::ChefRole:0x3fe2ed1f4b44>
[2] pry(#<Chef::Recipe>)> my_role.run_action(:create)
Chef::Exceptions::ValidationFailed: Option name's value #<Object:0x007fc5da8cfdc8> does not match regular expression /^[.\-[:alnum:]_]+$/
from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.0.current.0/lib/chef/mixin/params_validate.rb:299:in `_pv_regex'
```