### PR TITLE
Modified Resources and Providers creation

### DIFF
--- a/lib/chef/provider/chef_acl.rb
+++ b/lib/chef/provider/chef_acl.rb
@@ -4,7 +4,9 @@ require 'chef/chef_fs/data_handler/acl_data_handler'
 require 'chef/chef_fs/parallelizer'
 require 'uri'
 
-class Chef::Provider::ChefAcl < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefAcl < Cheffish::ChefProviderBase
   provides :chef_acl
 
   def whyrun_supported?
@@ -432,4 +434,6 @@ class Chef::Provider::ChefAcl < Cheffish::ChefProviderBase
       raise
     end
   end
+end
+end
 end

--- a/lib/chef/provider/chef_acl.rb
+++ b/lib/chef/provider/chef_acl.rb
@@ -5,435 +5,435 @@ require 'chef/chef_fs/parallelizer'
 require 'uri'
 
 class Chef
-class Provider
-class ChefAcl < Cheffish::ChefProviderBase
-  provides :chef_acl
+  class Provider
+    class ChefAcl < Cheffish::ChefProviderBase
+      provides :chef_acl
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    if new_resource.remove_rights && new_resource.complete
-      Chef::Log.warn("'remove_rights' is redundant when 'complete' is specified: all rights not specified in a 'rights' declaration will be removed.")
-    end
-    # Verify that we're not destroying all hope of ACL recovery here
-    if new_resource.complete && (!new_resource.rights || !new_resource.rights.any? { |r| r[:permissions].include?(:all) || r[:permissions].include?(:grant) })
-      # NOTE: if superusers exist, this should turn into a warning.
-      raise "'complete' specified on chef_acl resource, but no GRANT permissions were granted.  I'm sorry Dave, I can't let you remove all access to an object with no hope of recovery."
-    end
+      action :create do
+        if new_resource.remove_rights && new_resource.complete
+          Chef::Log.warn("'remove_rights' is redundant when 'complete' is specified: all rights not specified in a 'rights' declaration will be removed.")
+        end
+        # Verify that we're not destroying all hope of ACL recovery here
+        if new_resource.complete && (!new_resource.rights || !new_resource.rights.any? { |r| r[:permissions].include?(:all) || r[:permissions].include?(:grant) })
+          # NOTE: if superusers exist, this should turn into a warning.
+          raise "'complete' specified on chef_acl resource, but no GRANT permissions were granted.  I'm sorry Dave, I can't let you remove all access to an object with no hope of recovery."
+        end
 
-    # Find all matching paths so we can update them (resolve * and **)
-    paths = match_paths(new_resource.path)
-    if paths.size == 0 && !new_resource.path.split('/').any? { |p| p == '*' }
-      raise "Path #{new_resource.path} cannot have an ACL set on it!"
-    end
+        # Find all matching paths so we can update them (resolve * and **)
+        paths = match_paths(new_resource.path)
+        if paths.size == 0 && !new_resource.path.split('/').any? { |p| p == '*' }
+          raise "Path #{new_resource.path} cannot have an ACL set on it!"
+        end
 
-    # Go through the matches and update the ACLs for them
-    paths.each do |path|
-      create_acl(path)
-    end
-  end
+        # Go through the matches and update the ACLs for them
+        paths.each do |path|
+          create_acl(path)
+        end
+      end
 
-  # Update the ACL if necessary.
-  def create_acl(path)
-    changed = false
-    # There may not be an ACL path for some valid paths (/ and /organizations,
-    # for example).  We want to recurse into these, but we don't want to try to
-    # update nonexistent ACLs for them.
-    acl = acl_path(path)
-    if acl
-      # It's possible to make a custom container
-      current_json = current_acl(acl)
-      if current_json
+      # Update the ACL if necessary.
+      def create_acl(path)
+        changed = false
+        # There may not be an ACL path for some valid paths (/ and /organizations,
+        # for example).  We want to recurse into these, but we don't want to try to
+        # update nonexistent ACLs for them.
+        acl = acl_path(path)
+        if acl
+          # It's possible to make a custom container
+          current_json = current_acl(acl)
+          if current_json
 
-        # Compare the desired and current json for the ACL, and update if different.
-        modify = {}
-        desired_acl(acl).each do |permission, desired_json|
-          differences = json_differences(current_json[permission], desired_json)
+            # Compare the desired and current json for the ACL, and update if different.
+            modify = {}
+            desired_acl(acl).each do |permission, desired_json|
+              differences = json_differences(current_json[permission], desired_json)
 
-          if differences.size > 0
-            # Verify we aren't trying to destroy grant permissions
-            if permission == 'grant' && desired_json['actors'] == [] && desired_json['groups'] == []
-              # NOTE: if superusers exist, this should turn into a warning.
-              raise "chef_acl attempted to remove all actors from GRANT!  I'm sorry Dave, I can't let you remove access to an object with no hope of recovery."
+              if differences.size > 0
+                # Verify we aren't trying to destroy grant permissions
+                if permission == 'grant' && desired_json['actors'] == [] && desired_json['groups'] == []
+                  # NOTE: if superusers exist, this should turn into a warning.
+                  raise "chef_acl attempted to remove all actors from GRANT!  I'm sorry Dave, I can't let you remove access to an object with no hope of recovery."
+                end
+                modify[differences] ||= {}
+                modify[differences][permission] = desired_json
+              end
             end
-            modify[differences] ||= {}
-            modify[differences][permission] = desired_json
+
+            if modify.size > 0
+              changed = true
+              description = [ "update acl #{path} at #{rest_url(path)}" ] + modify.map do |diffs, permissions|
+                diffs.map { |diff| "  #{permissions.keys.join(', ')}:#{diff}" }
+              end.flatten(1)
+              converge_by description do
+                modify.values.each do |permissions|
+                  permissions.each do |permission, desired_json|
+                    rest.put(rest_url("#{acl}/#{permission}"), { permission => desired_json })
+                  end
+                end
+              end
+            end
           end
         end
 
-        if modify.size > 0
-          changed = true
-          description = [ "update acl #{path} at #{rest_url(path)}" ] + modify.map do |diffs, permissions|
-            diffs.map { |diff| "  #{permissions.keys.join(', ')}:#{diff}" }
-          end.flatten(1)
-          converge_by description do
-            modify.values.each do |permissions|
-              permissions.each do |permission, desired_json|
-                rest.put(rest_url("#{acl}/#{permission}"), { permission => desired_json })
+        # If we have been asked to recurse, do so.
+        # If recurse is on_change, then we will recurse if there is no ACL, or if
+        # the ACL has changed.
+        if new_resource.recursive == true || (new_resource.recursive == :on_change && (!acl || changed))
+          children, error = list(path, '*')
+          Chef::ChefFS::Parallelizer.parallel_do(children) do |child|
+            next if child.split('/')[-1] == 'containers'
+            create_acl(child)
+          end
+          # containers mess up our descent, so we do them last
+          Chef::ChefFS::Parallelizer.parallel_do(children) do |child|
+            next if child.split('/')[-1] != 'containers'
+            create_acl(child)
+          end
+
+        end
+      end
+
+      # Get the current ACL for the given path
+      def current_acl(acl_path)
+        @current_acls ||= {}
+        if !@current_acls.has_key?(acl_path)
+          @current_acls[acl_path] = begin
+            rest.get(rest_url(acl_path))
+          rescue Net::HTTPServerException => e
+            unless e.response.code == '404' && new_resource.path.split('/').any? { |p| p == '*' }
+              raise
+            end
+          end
+        end
+        @current_acls[acl_path]
+      end
+
+      # Get the desired acl for the given acl path
+      def desired_acl(acl_path)
+        result = new_resource.raw_json ? new_resource.raw_json.dup : {}
+
+        # Calculate the JSON based on rights
+        add_rights(acl_path, result)
+
+        if new_resource.complete
+          result = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(result, nil)
+        else
+          # If resource is incomplete, use current json to fill any holes
+          current_acl(acl_path).each do |permission, perm_hash|
+            if !result[permission]
+              result[permission] = perm_hash.dup
+            else
+              result[permission] = result[permission].dup
+              perm_hash.each do |type, actors|
+                if !result[permission][type]
+                  result[permission][type] = actors
+                else
+                  result[permission][type] = result[permission][type].dup
+                  result[permission][type] |= actors
+                end
+              end
+            end
+          end
+
+          remove_rights(result)
+        end
+        result
+      end
+
+      def add_rights(acl_path, json)
+        if new_resource.rights
+          new_resource.rights.each do |rights|
+            if rights[:permissions].delete(:all)
+              rights[:permissions] |= current_acl(acl_path).keys
+            end
+
+            Array(rights[:permissions]).each do |permission|
+              ace = json[permission.to_s] ||= {}
+              # WTF, no distinction between users and clients?  The Chef API doesn't
+              # let us distinguish, so we have no choice :/  This means that:
+              # 1. If you specify :users => 'foo', and client 'foo' exists, it will
+              #    pick that (whether user 'foo' exists or not)
+              # 2. If you specify :clients => 'foo', and user 'foo' exists but
+              #    client 'foo' does not, it will pick user 'foo' and put it in the
+              #    ACL
+              # 3. If an existing item has user 'foo' on it and you specify :clients
+              #    => 'foo' instead, idempotence will not notice that anything needs
+              #    to be updated and nothing will happen.
+              if rights[:users]
+                ace['actors'] ||= []
+                ace['actors'] |= Array(rights[:users])
+              end
+              if rights[:clients]
+                ace['actors'] ||= []
+                ace['actors'] |= Array(rights[:clients])
+              end
+              if rights[:groups]
+                ace['groups'] ||= []
+                ace['groups'] |= Array(rights[:groups])
               end
             end
           end
         end
       end
-    end
 
-    # If we have been asked to recurse, do so.
-    # If recurse is on_change, then we will recurse if there is no ACL, or if
-    # the ACL has changed.
-    if new_resource.recursive == true || (new_resource.recursive == :on_change && (!acl || changed))
-      children, error = list(path, '*')
-      Chef::ChefFS::Parallelizer.parallel_do(children) do |child|
-        next if child.split('/')[-1] == 'containers'
-        create_acl(child)
+      def remove_rights(json)
+        if new_resource.remove_rights
+          new_resource.remove_rights.each do |rights|
+            rights[:permissions].each do |permission|
+              if permission == :all
+                json.each_key do |key|
+                  ace = json[key] = json[key.dup]
+                  ace['actors'] = ace['actors'] - Array(rights[:users])   if rights[:users]   && ace['actors']
+                  ace['actors'] = ace['actors'] - Array(rights[:clients]) if rights[:clients] && ace['actors']
+                  ace['groups'] = ace['groups'] - Array(rights[:groups])  if rights[:groups]  && ace['groups']
+                end
+              else
+                ace = json[permission.to_s] = json[permission.to_s].dup
+                if ace
+                  ace['actors'] = ace['actors'] - Array(rights[:users])   if rights[:users]   && ace['actors']
+                  ace['actors'] = ace['actors'] - Array(rights[:clients]) if rights[:clients] && ace['actors']
+                  ace['groups'] = ace['groups'] - Array(rights[:groups])  if rights[:groups]  && ace['groups']
+                end
+              end
+            end
+          end
+        end
       end
-      # containers mess up our descent, so we do them last
-      Chef::ChefFS::Parallelizer.parallel_do(children) do |child|
-        next if child.split('/')[-1] != 'containers'
-        create_acl(child)
+
+      def load_current_resource
       end
 
-    end
-  end
+      #
+      # Matches chef_acl paths like nodes, nodes/*.
+      #
+      # == Examples
+      # match_paths('nodes'): [ 'nodes' ]
+      # match_paths('nodes/*'): [ 'nodes/x', 'nodes/y', 'nodes/z' ]
+      # match_paths('*'): [ 'clients', 'environments', 'nodes', 'roles', ... ]
+      # match_paths('/'): [ '/' ]
+      # match_paths(''): [ '' ]
+      # match_paths('/*'): [ '/organizations', '/users' ]
+      # match_paths('/organizations/*/*'): [ '/organizations/foo/clients', '/organizations/foo/environments', ..., '/organizations/bar/clients', '/organizations/bar/environments', ... ]
+      #
+      def match_paths(path)
+        # Turn multiple slashes into one
+        # nodes//x -> nodes/x
+        path = path.gsub(/[\/]+/, '/')
+        # If it's absolute, start the matching with /.  If it's relative, start with '' (relative root).
+        if path[0] == '/'
+          matches = [ '/' ]
+        else
+          matches = [ '' ]
+        end
 
-  # Get the current ACL for the given path
-  def current_acl(acl_path)
-    @current_acls ||= {}
-    if !@current_acls.has_key?(acl_path)
-      @current_acls[acl_path] = begin
-        rest.get(rest_url(acl_path))
-      rescue Net::HTTPServerException => e
-        unless e.response.code == '404' && new_resource.path.split('/').any? { |p| p == '*' }
+        # Split the path, and get rid of the empty path at the beginning and end
+        # (/a/b/c/ -> [ 'a', 'b', 'c' ])
+        parts = path.split('/').select { |x| x != '' }.to_a
+
+        # Descend until we find the matches:
+        # path = 'a/b/c'
+        # parts = [ 'a', 'b', 'c' ]
+        # Starting matches = [ '' ]
+        parts.each_with_index do |part, index|
+          # For each match, list <match>/<part> and set matches to that.
+          #
+          # Example: /*/foo
+          # 1. To start,
+          #    matches = [ '/' ], part = '*'.
+          #    list('/', '*')                = [ '/organizations, '/users' ]
+          # 2. matches = [ '/organizations', '/users' ], part = 'foo'
+          #    list('/organizations', 'foo') = [ '/organizations/foo' ]
+          #    list('/users', 'foo')         = [ '/users/foo' ]
+          #
+          # Result: /*/foo = [ '/organizations/foo', '/users/foo' ]
+          #
+          matches = Chef::ChefFS::Parallelizer.parallelize(matches) do |path|
+            found, error = list(path, part)
+            if error
+              if parts[0..index-1].all? { |p| p != '*' }
+                raise error
+              end
+              []
+            else
+              found
+            end
+          end.flatten(1).to_a
+        end
+
+        matches
+      end
+
+      #
+      # Takes a normal path and finds the Chef path to get / set its ACL.
+      #
+      # nodes/x -> nodes/x/_acl
+      # nodes -> containers/nodes/_acl
+      # '' -> organizations/_acl (the org acl)
+      # /organizations/foo -> /organizations/foo/organizations/_acl
+      # /users/foo -> /users/foo/_acl
+      # /organizations/foo/nodes/x -> /organizations/foo/nodes/x/_acl
+      #
+      def acl_path(path)
+        parts = path.split('/').select { |x| x != '' }.to_a
+        prefix = (path[0] == '/') ? '/' : ''
+
+        case parts.size
+        when 0
+          # /, empty (relative root)
+          # The root of the server has no publicly visible ACLs.  Only nodes/*, etc.
+          if prefix == ''
+            ::File.join('organizations', '_acl')
+          end
+
+        when 1
+          # nodes, roles, etc.
+          # The top level organizations and users containers have no publicly
+          # visible ACLs.  Only nodes/*, etc.
+          if prefix == ''
+            ::File.join('containers', path, '_acl')
+          end
+
+        when 2
+          # /organizations/NAME, /users/NAME, nodes/NAME, roles/NAME, etc.
+          if prefix == '/' && parts[0] == 'organizations'
+            ::File.join(path, 'organizations', '_acl')
+          else
+            ::File.join(path, '_acl')
+          end
+
+        when 3
+          # /organizations/NAME/nodes, cookbooks/NAME/VERSION, etc.
+          if prefix == '/'
+            ::File.join('/', parts[0], parts[1], 'containers', parts[2], '_acl')
+          else
+            ::File.join(parts[0], parts[1], '_acl')
+          end
+
+        when 4
+          # /organizations/NAME/nodes/NAME, cookbooks/NAME/VERSION/BLAH
+          # /organizations/NAME/nodes/NAME, cookbooks/NAME/VERSION, etc.
+          if prefix == '/'
+            ::File.join(path, '_acl')
+          else
+            ::File.join(parts[0], parts[1], '_acl')
+          end
+
+        else
+          # /organizations/NAME/cookbooks/NAME/VERSION/..., cookbooks/NAME/VERSION/A/B/...
+          if prefix == '/'
+            ::File.join('/', parts[0], parts[1], parts[2], parts[3], '_acl')
+          else
+            ::File.join(parts[0], parts[1], '_acl')
+          end
+        end
+      end
+
+      #
+      # Lists the securable children under a path (the ones that either have ACLs
+      # or have children with ACLs).
+      #
+      # list('nodes', 'x') -> [ 'nodes/x' ]
+      # list('nodes', '*') -> [ 'nodes/x', 'nodes/y', 'nodes/z' ]
+      # list('', '*') -> [ 'clients', 'environments', 'nodes', 'roles', ... ]
+      # list('/', '*') -> [ '/organizations']
+      # list('cookbooks', 'x') -> [ 'cookbooks/x' ]
+      # list('cookbooks/x', '*') -> [ ] # Individual cookbook versions do not have their own ACLs
+      # list('/organizations/foo/nodes', '*') -> [ '/organizations/foo/nodes/x', '/organizations/foo/nodes/y' ]
+      #
+      # The list of children of an organization is == the list of containers.  If new
+      # containers are added, the list of children will grow.  This allows the system
+      # to extend to new types of objects and allow cheffish to work with them.
+      #
+      def list(path, child)
+        # TODO make ChefFS understand top level organizations and stop doing this altogether.
+        parts = path.split('/').select { |x| x != '' }.to_a
+        absolute = (path[0] == '/')
+        if absolute && parts[0] == 'organizations'
+          return [ [], "ACLs cannot be set on children of #{path}" ] if parts.size > 3
+        else
+          return [ [], "ACLs cannot be set on children of #{path}" ] if parts.size > 1
+        end
+
+        error = nil
+
+        if child == '*'
+          case parts.size
+          when 0
+            # /*, *
+            if absolute
+              results = [ "/organizations", "/users" ]
+            else
+              results, error = rest_list("containers")
+            end
+
+          when 1
+            # /organizations/*, /users/*, roles/*, nodes/*, etc.
+            results, error = rest_list(path)
+            if !error
+              results = results.map { |result| ::File.join(path, result) }
+            end
+
+          when 2
+            # /organizations/NAME/*
+            results, error = rest_list(::File.join(path, 'containers'))
+            if !error
+              results = results.map { |result| ::File.join(path, result) }
+            end
+
+          when 3
+            # /organizations/NAME/TYPE/*
+            results, error = rest_list(path)
+            if !error
+              results = results.map { |result| ::File.join(path, result) }
+            end
+          end
+
+        else
+          if child == 'data_bags' &&
+            (parts.size == 0 || (parts.size == 2 && parts[0] == 'organizations'))
+            child = 'data'
+          end
+
+          if absolute
+            # /<child>, /users/<child>, /organizations/<child>, /organizations/foo/<child>, /organizations/foo/nodes/<child> ...
+            results = [ ::File.join('/', parts[0..2], child) ]
+          elsif parts.size == 0
+            # <child> (nodes, roles, etc.)
+            results = [ child ]
+          else
+            # nodes/<child>, roles/<child>, etc.
+            results = [ ::File.join(parts[0], child) ]
+          end
+        end
+
+        [ results, error ]
+      end
+
+      def rest_url(path)
+        path[0] == '/' ? URI.join(rest.url, path) : path
+      end
+
+      def rest_list(path)
+        begin
+          # All our rest lists are hashes where the keys are the names
+          [ rest.get(rest_url(path)).keys, nil ]
+        rescue Net::HTTPServerException => e
+          if e.response.code == '405' || e.response.code == '404'
+            parts = path.split('/').select { |p| p != '' }.to_a
+
+            # We KNOW we expect these to exist.  Other containers may or may not.
+            unless (parts.size == 1 || (parts.size == 3 && parts[0] == 'organizations')) &&
+              %w(clients containers cookbooks data environments groups nodes roles).include?(parts[-1])
+              return [ [], "Cannot get list of #{path}: HTTP response code #{e.response.code}" ]
+            end
+          end
           raise
         end
       end
     end
-    @current_acls[acl_path]
   end
-
-  # Get the desired acl for the given acl path
-  def desired_acl(acl_path)
-    result = new_resource.raw_json ? new_resource.raw_json.dup : {}
-
-    # Calculate the JSON based on rights
-    add_rights(acl_path, result)
-
-    if new_resource.complete
-      result = Chef::ChefFS::DataHandler::AclDataHandler.new.normalize(result, nil)
-    else
-      # If resource is incomplete, use current json to fill any holes
-      current_acl(acl_path).each do |permission, perm_hash|
-        if !result[permission]
-          result[permission] = perm_hash.dup
-        else
-          result[permission] = result[permission].dup
-          perm_hash.each do |type, actors|
-            if !result[permission][type]
-              result[permission][type] = actors
-            else
-              result[permission][type] = result[permission][type].dup
-              result[permission][type] |= actors
-            end
-          end
-        end
-      end
-
-      remove_rights(result)
-    end
-    result
-  end
-
-  def add_rights(acl_path, json)
-    if new_resource.rights
-      new_resource.rights.each do |rights|
-        if rights[:permissions].delete(:all)
-          rights[:permissions] |= current_acl(acl_path).keys
-        end
-
-        Array(rights[:permissions]).each do |permission|
-          ace = json[permission.to_s] ||= {}
-          # WTF, no distinction between users and clients?  The Chef API doesn't
-          # let us distinguish, so we have no choice :/  This means that:
-          # 1. If you specify :users => 'foo', and client 'foo' exists, it will
-          #    pick that (whether user 'foo' exists or not)
-          # 2. If you specify :clients => 'foo', and user 'foo' exists but
-          #    client 'foo' does not, it will pick user 'foo' and put it in the
-          #    ACL
-          # 3. If an existing item has user 'foo' on it and you specify :clients
-          #    => 'foo' instead, idempotence will not notice that anything needs
-          #    to be updated and nothing will happen.
-          if rights[:users]
-            ace['actors'] ||= []
-            ace['actors'] |= Array(rights[:users])
-          end
-          if rights[:clients]
-            ace['actors'] ||= []
-            ace['actors'] |= Array(rights[:clients])
-          end
-          if rights[:groups]
-            ace['groups'] ||= []
-            ace['groups'] |= Array(rights[:groups])
-          end
-        end
-      end
-    end
-  end
-
-  def remove_rights(json)
-    if new_resource.remove_rights
-      new_resource.remove_rights.each do |rights|
-        rights[:permissions].each do |permission|
-          if permission == :all
-            json.each_key do |key|
-              ace = json[key] = json[key.dup]
-              ace['actors'] = ace['actors'] - Array(rights[:users])   if rights[:users]   && ace['actors']
-              ace['actors'] = ace['actors'] - Array(rights[:clients]) if rights[:clients] && ace['actors']
-              ace['groups'] = ace['groups'] - Array(rights[:groups])  if rights[:groups]  && ace['groups']
-            end
-          else
-            ace = json[permission.to_s] = json[permission.to_s].dup
-            if ace
-              ace['actors'] = ace['actors'] - Array(rights[:users])   if rights[:users]   && ace['actors']
-              ace['actors'] = ace['actors'] - Array(rights[:clients]) if rights[:clients] && ace['actors']
-              ace['groups'] = ace['groups'] - Array(rights[:groups])  if rights[:groups]  && ace['groups']
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def load_current_resource
-  end
-
-  #
-  # Matches chef_acl paths like nodes, nodes/*.
-  #
-  # == Examples
-  # match_paths('nodes'): [ 'nodes' ]
-  # match_paths('nodes/*'): [ 'nodes/x', 'nodes/y', 'nodes/z' ]
-  # match_paths('*'): [ 'clients', 'environments', 'nodes', 'roles', ... ]
-  # match_paths('/'): [ '/' ]
-  # match_paths(''): [ '' ]
-  # match_paths('/*'): [ '/organizations', '/users' ]
-  # match_paths('/organizations/*/*'): [ '/organizations/foo/clients', '/organizations/foo/environments', ..., '/organizations/bar/clients', '/organizations/bar/environments', ... ]
-  #
-  def match_paths(path)
-    # Turn multiple slashes into one
-    # nodes//x -> nodes/x
-    path = path.gsub(/[\/]+/, '/')
-    # If it's absolute, start the matching with /.  If it's relative, start with '' (relative root).
-    if path[0] == '/'
-      matches = [ '/' ]
-    else
-      matches = [ '' ]
-    end
-
-    # Split the path, and get rid of the empty path at the beginning and end
-    # (/a/b/c/ -> [ 'a', 'b', 'c' ])
-    parts = path.split('/').select { |x| x != '' }.to_a
-
-    # Descend until we find the matches:
-    # path = 'a/b/c'
-    # parts = [ 'a', 'b', 'c' ]
-    # Starting matches = [ '' ]
-    parts.each_with_index do |part, index|
-      # For each match, list <match>/<part> and set matches to that.
-      #
-      # Example: /*/foo
-      # 1. To start,
-      #    matches = [ '/' ], part = '*'.
-      #    list('/', '*')                = [ '/organizations, '/users' ]
-      # 2. matches = [ '/organizations', '/users' ], part = 'foo'
-      #    list('/organizations', 'foo') = [ '/organizations/foo' ]
-      #    list('/users', 'foo')         = [ '/users/foo' ]
-      #
-      # Result: /*/foo = [ '/organizations/foo', '/users/foo' ]
-      #
-      matches = Chef::ChefFS::Parallelizer.parallelize(matches) do |path|
-        found, error = list(path, part)
-        if error
-          if parts[0..index-1].all? { |p| p != '*' }
-            raise error
-          end
-          []
-        else
-          found
-        end
-      end.flatten(1).to_a
-    end
-
-    matches
-  end
-
-  #
-  # Takes a normal path and finds the Chef path to get / set its ACL.
-  #
-  # nodes/x -> nodes/x/_acl
-  # nodes -> containers/nodes/_acl
-  # '' -> organizations/_acl (the org acl)
-  # /organizations/foo -> /organizations/foo/organizations/_acl
-  # /users/foo -> /users/foo/_acl
-  # /organizations/foo/nodes/x -> /organizations/foo/nodes/x/_acl
-  #
-  def acl_path(path)
-    parts = path.split('/').select { |x| x != '' }.to_a
-    prefix = (path[0] == '/') ? '/' : ''
-
-    case parts.size
-    when 0
-      # /, empty (relative root)
-      # The root of the server has no publicly visible ACLs.  Only nodes/*, etc.
-      if prefix == ''
-        ::File.join('organizations', '_acl')
-      end
-
-    when 1
-      # nodes, roles, etc.
-      # The top level organizations and users containers have no publicly
-      # visible ACLs.  Only nodes/*, etc.
-      if prefix == ''
-        ::File.join('containers', path, '_acl')
-      end
-
-    when 2
-      # /organizations/NAME, /users/NAME, nodes/NAME, roles/NAME, etc.
-      if prefix == '/' && parts[0] == 'organizations'
-        ::File.join(path, 'organizations', '_acl')
-      else
-        ::File.join(path, '_acl')
-      end
-
-    when 3
-      # /organizations/NAME/nodes, cookbooks/NAME/VERSION, etc.
-      if prefix == '/'
-        ::File.join('/', parts[0], parts[1], 'containers', parts[2], '_acl')
-      else
-        ::File.join(parts[0], parts[1], '_acl')
-      end
-
-    when 4
-      # /organizations/NAME/nodes/NAME, cookbooks/NAME/VERSION/BLAH
-      # /organizations/NAME/nodes/NAME, cookbooks/NAME/VERSION, etc.
-      if prefix == '/'
-        ::File.join(path, '_acl')
-      else
-        ::File.join(parts[0], parts[1], '_acl')
-      end
-
-    else
-      # /organizations/NAME/cookbooks/NAME/VERSION/..., cookbooks/NAME/VERSION/A/B/...
-      if prefix == '/'
-        ::File.join('/', parts[0], parts[1], parts[2], parts[3], '_acl')
-      else
-        ::File.join(parts[0], parts[1], '_acl')
-      end
-    end
-  end
-
-  #
-  # Lists the securable children under a path (the ones that either have ACLs
-  # or have children with ACLs).
-  #
-  # list('nodes', 'x') -> [ 'nodes/x' ]
-  # list('nodes', '*') -> [ 'nodes/x', 'nodes/y', 'nodes/z' ]
-  # list('', '*') -> [ 'clients', 'environments', 'nodes', 'roles', ... ]
-  # list('/', '*') -> [ '/organizations']
-  # list('cookbooks', 'x') -> [ 'cookbooks/x' ]
-  # list('cookbooks/x', '*') -> [ ] # Individual cookbook versions do not have their own ACLs
-  # list('/organizations/foo/nodes', '*') -> [ '/organizations/foo/nodes/x', '/organizations/foo/nodes/y' ]
-  #
-  # The list of children of an organization is == the list of containers.  If new
-  # containers are added, the list of children will grow.  This allows the system
-  # to extend to new types of objects and allow cheffish to work with them.
-  #
-  def list(path, child)
-    # TODO make ChefFS understand top level organizations and stop doing this altogether.
-    parts = path.split('/').select { |x| x != '' }.to_a
-    absolute = (path[0] == '/')
-    if absolute && parts[0] == 'organizations'
-      return [ [], "ACLs cannot be set on children of #{path}" ] if parts.size > 3
-    else
-      return [ [], "ACLs cannot be set on children of #{path}" ] if parts.size > 1
-    end
-
-    error = nil
-
-    if child == '*'
-      case parts.size
-      when 0
-        # /*, *
-        if absolute
-          results = [ "/organizations", "/users" ]
-        else
-          results, error = rest_list("containers")
-        end
-
-      when 1
-        # /organizations/*, /users/*, roles/*, nodes/*, etc.
-        results, error = rest_list(path)
-        if !error
-          results = results.map { |result| ::File.join(path, result) }
-        end
-
-      when 2
-        # /organizations/NAME/*
-        results, error = rest_list(::File.join(path, 'containers'))
-        if !error
-          results = results.map { |result| ::File.join(path, result) }
-        end
-
-      when 3
-        # /organizations/NAME/TYPE/*
-        results, error = rest_list(path)
-        if !error
-          results = results.map { |result| ::File.join(path, result) }
-        end
-      end
-
-    else
-      if child == 'data_bags' &&
-        (parts.size == 0 || (parts.size == 2 && parts[0] == 'organizations'))
-        child = 'data'
-      end
-
-      if absolute
-        # /<child>, /users/<child>, /organizations/<child>, /organizations/foo/<child>, /organizations/foo/nodes/<child> ...
-        results = [ ::File.join('/', parts[0..2], child) ]
-      elsif parts.size == 0
-        # <child> (nodes, roles, etc.)
-        results = [ child ]
-      else
-        # nodes/<child>, roles/<child>, etc.
-        results = [ ::File.join(parts[0], child) ]
-      end
-    end
-
-    [ results, error ]
-  end
-
-  def rest_url(path)
-    path[0] == '/' ? URI.join(rest.url, path) : path
-  end
-
-  def rest_list(path)
-    begin
-      # All our rest lists are hashes where the keys are the names
-      [ rest.get(rest_url(path)).keys, nil ]
-    rescue Net::HTTPServerException => e
-      if e.response.code == '405' || e.response.code == '404'
-        parts = path.split('/').select { |p| p != '' }.to_a
-
-        # We KNOW we expect these to exist.  Other containers may or may not.
-        unless (parts.size == 1 || (parts.size == 3 && parts[0] == 'organizations')) &&
-          %w(clients containers cookbooks data environments groups nodes roles).include?(parts[-1])
-          return [ [], "Cannot get list of #{path}: HTTP response code #{e.response.code}" ]
-        end
-      end
-      raise
-    end
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_client.rb
+++ b/lib/chef/provider/chef_client.rb
@@ -3,51 +3,51 @@ require 'chef/resource/chef_client'
 require 'chef/chef_fs/data_handler/client_data_handler'
 
 class Chef
-class Provider
-class ChefClient < Cheffish::ActorProviderBase
-  provides :chef_client
+  class Provider
+    class ChefClient < Cheffish::ActorProviderBase
+      provides :chef_client
 
-  def whyrun_supported?
-    true
+      def whyrun_supported?
+        true
+      end
+
+      def actor_type
+        'client'
+      end
+
+      def actor_path
+        'clients'
+      end
+
+      action :create do
+        create_actor
+      end
+
+      action :delete do
+        delete_actor
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefClient
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::ClientDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'admin' => :admin,
+          'validator' => :validator,
+          'public_key' => :source_key
+        }
+      end
+
+    end
   end
-
-  def actor_type
-    'client'
-  end
-
-  def actor_path
-    'clients'
-  end
-
-  action :create do
-    create_actor
-  end
-
-  action :delete do
-    delete_actor
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefClient
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::ClientDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'admin' => :admin,
-      'validator' => :validator,
-      'public_key' => :source_key
-    }
-  end
-
-end
-end
 end

--- a/lib/chef/provider/chef_client.rb
+++ b/lib/chef/provider/chef_client.rb
@@ -2,7 +2,9 @@ require 'cheffish/actor_provider_base'
 require 'chef/resource/chef_client'
 require 'chef/chef_fs/data_handler/client_data_handler'
 
-class Chef::Provider::ChefClient < Cheffish::ActorProviderBase
+class Chef
+class Provider
+class ChefClient < Cheffish::ActorProviderBase
   provides :chef_client
 
   def whyrun_supported?
@@ -46,4 +48,6 @@ class Chef::Provider::ChefClient < Cheffish::ActorProviderBase
     }
   end
 
+end
+end
 end

--- a/lib/chef/provider/chef_container.rb
+++ b/lib/chef/provider/chef_container.rb
@@ -3,53 +3,53 @@ require 'chef/resource/chef_container'
 require 'chef/chef_fs/data_handler/container_data_handler'
 
 class Chef
-class Provider
-class ChefContainer < Cheffish::ChefProviderBase
-  provides :chef_container
+  class Provider
+    class ChefContainer < Cheffish::ChefProviderBase
+      provides :chef_container
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    if !@current_exists
-      converge_by "create container #{new_resource.name} at #{rest.url}" do
-        rest.post("containers", normalize_for_post(new_json))
+      action :create do
+        if !@current_exists
+          converge_by "create container #{new_resource.name} at #{rest.url}" do
+            rest.post("containers", normalize_for_post(new_json))
+          end
+        end
+      end
+
+      action :delete do
+        if @current_exists
+          converge_by "delete container #{new_resource.name} at #{rest.url}" do
+            rest.delete("containers/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_exists = rest.get("containers/#{new_resource.name}")
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_exists = false
+          else
+            raise
+          end
+        end
+      end
+
+      def new_json
+        {}
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::ContainerDataHandler.new
+      end
+
+      def keys
+        { 'containername' => :name, 'containerpath' => :name }
       end
     end
   end
-
-  action :delete do
-    if @current_exists
-      converge_by "delete container #{new_resource.name} at #{rest.url}" do
-        rest.delete("containers/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_exists = rest.get("containers/#{new_resource.name}")
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_exists = false
-      else
-        raise
-      end
-    end
-  end
-
-  def new_json
-    {}
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::ContainerDataHandler.new
-  end
-
-  def keys
-    { 'containername' => :name, 'containerpath' => :name }
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_container.rb
+++ b/lib/chef/provider/chef_container.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_container'
 require 'chef/chef_fs/data_handler/container_data_handler'
 
-class Chef::Provider::ChefContainer < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefContainer < Cheffish::ChefProviderBase
   provides :chef_container
 
   def whyrun_supported?
@@ -48,4 +50,6 @@ class Chef::Provider::ChefContainer < Cheffish::ChefProviderBase
   def keys
     { 'containername' => :name, 'containerpath' => :name }
   end
+end
+end
 end

--- a/lib/chef/provider/chef_data_bag.rb
+++ b/lib/chef/provider/chef_data_bag.rb
@@ -2,54 +2,54 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_data_bag'
 
 class Chef
-class Provider
-class ChefDataBag < Cheffish::ChefProviderBase
-  provides :chef_data_bag
+  class Provider
+    class ChefDataBag < Cheffish::ChefProviderBase
+      provides :chef_data_bag
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    if !current_resource_exists?
-      converge_by "create data bag #{new_resource.name} at #{rest.url}" do
-        rest.post("data", { 'name' => new_resource.name })
+      action :create do
+        if !current_resource_exists?
+          converge_by "create data bag #{new_resource.name} at #{rest.url}" do
+            rest.post("data", { 'name' => new_resource.name })
+          end
+        end
+      end
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete data bag #{new_resource.name} at #{rest.url}" do
+            rest.delete("data/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("data/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      #
+      # Helpers
+      #
+      # Gives us new_json, current_json, not_found_json, etc.
+
+      def resource_class
+        Chef::Resource::ChefDataBag
+      end
+
+      def json_to_resource(json)
+        Chef::Resource::ChefDataBag.new(json['name'], run_context)
       end
     end
   end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete data bag #{new_resource.name} at #{rest.url}" do
-        rest.delete("data/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("data/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  #
-  # Helpers
-  #
-  # Gives us new_json, current_json, not_found_json, etc.
-
-  def resource_class
-    Chef::Resource::ChefDataBag
-  end
-
-  def json_to_resource(json)
-    Chef::Resource::ChefDataBag.new(json['name'], run_context)
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_data_bag.rb
+++ b/lib/chef/provider/chef_data_bag.rb
@@ -1,7 +1,9 @@
 require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_data_bag'
 
-class Chef::Provider::ChefDataBag < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefDataBag < Cheffish::ChefProviderBase
   provides :chef_data_bag
 
   def whyrun_supported?
@@ -48,4 +50,6 @@ class Chef::Provider::ChefDataBag < Cheffish::ChefProviderBase
   def json_to_resource(json)
     Chef::Resource::ChefDataBag.new(json['name'], run_context)
   end
+end
+end
 end

--- a/lib/chef/provider/chef_data_bag_item.rb
+++ b/lib/chef/provider/chef_data_bag_item.rb
@@ -3,7 +3,9 @@ require 'chef/resource/chef_data_bag_item'
 require 'chef/chef_fs/data_handler/data_bag_item_data_handler'
 require 'chef/encrypted_data_bag_item'
 
-class Chef::Provider::ChefDataBagItem < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefDataBagItem < Cheffish::ChefProviderBase
   provides :chef_data_bag_item
 
   def whyrun_supported?
@@ -271,4 +273,6 @@ class Chef::Provider::ChefDataBagItem < Cheffish::ChefProviderBase
     FakeEntry.new("#{new_resource.id}.json", FakeEntry.new(new_resource.data_bag))
   end
 
+end
+end
 end

--- a/lib/chef/provider/chef_data_bag_item.rb
+++ b/lib/chef/provider/chef_data_bag_item.rb
@@ -4,275 +4,275 @@ require 'chef/chef_fs/data_handler/data_bag_item_data_handler'
 require 'chef/encrypted_data_bag_item'
 
 class Chef
-class Provider
-class ChefDataBagItem < Cheffish::ChefProviderBase
-  provides :chef_data_bag_item
+  class Provider
+    class ChefDataBagItem < Cheffish::ChefProviderBase
+      provides :chef_data_bag_item
 
-  def whyrun_supported?
-    true
-  end
-
-  action :create do
-    differences = calculate_differences
-
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update data bag item #{new_resource.id} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("data/#{new_resource.data_bag}/#{new_resource.id}", normalize_for_put(new_json))
-        end
+      def whyrun_supported?
+        true
       end
-    else
-      description = [ "create data bag item #{new_resource.id} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("data/#{new_resource.data_bag}", normalize_for_post(new_json))
-      end
-    end
-  end
 
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete data bag item #{new_resource.id} at #{rest.url}" do
-        rest.delete("data/#{new_resource.data_bag}/#{new_resource.id}")
-      end
-    end
-  end
+      action :create do
+        differences = calculate_differences
 
-  def load_current_resource
-    begin
-      json = rest.get("data/#{new_resource.data_bag}/#{new_resource.id}")
-      resource = Chef::Resource::ChefDataBagItem.new(new_resource.name, run_context)
-      resource.raw_data json
-      @current_resource = resource
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-
-    # Determine if data bag is encrypted and if so, what its version is
-    first_real_key, first_real_value = (current_resource.raw_data || {}).select { |key, value| key != 'id' && !value.nil? }.first
-    if first_real_value
-      if first_real_value.is_a?(Hash) &&
-         first_real_value['version'].is_a?(Integer) &&
-         first_real_value['version'] > 0 &&
-         first_real_value.has_key?('encrypted_data')
-
-        current_resource.encrypt true
-        current_resource.encryption_version first_real_value['version']
-
-        decrypt_error = nil
-
-        # Check if the desired secret is the one (which it generally should be)
-
-        if new_resource.secret || new_resource.secret_path
-          begin
-            Chef::EncryptedDataBagItem::Decryptor.for(first_real_value, new_secret).for_decrypted_item
-            current_resource.secret new_secret
-          rescue Chef::EncryptedDataBagItem::DecryptionFailure
-            decrypt_error = $!
-          end
-        end
-
-        # If the current secret doesn't work, look through the specified old secrets
-
-        if !current_resource.secret
-          old_secrets = []
-          if new_resource.old_secret
-            old_secrets += Array(new_resource.old_secret)
-          end
-          if new_resource.old_secret_path
-            old_secrets += Array(new_resource.old_secret_path).map do |secret_path|
-              Chef::EncryptedDataBagItem.load_secret(new_resource.old_secret_file)
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update data bag item #{new_resource.id} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("data/#{new_resource.data_bag}/#{new_resource.id}", normalize_for_put(new_json))
             end
           end
-          old_secrets.each do |secret|
-            begin
-              Chef::EncryptedDataBagItem::Decryptor.for(first_real_value, secret).for_decrypted_item
-              current_resource.secret secret
-            rescue Chef::EncryptedDataBagItem::DecryptionFailure
-              decrypt_error = $!
-            end
-          end
-
-          # If we couldn't figure out the secret, emit a warning (this isn't a fatal flaw unless we
-          # need to reuse one of the values from the data bag)
-          if !current_resource.secret
-            if decrypt_error
-              Chef::Log.warn "Existing data bag is encrypted, but could not decrypt: #{decrypt_error.message}."
-            else
-              Chef::Log.warn "Existing data bag is encrypted, but no secret was specified."
-            end
-          end
-        end
-      end
-    else
-
-      # There are no encryptable values, so pretend encryption is the same as desired
-
-      current_resource.encrypt new_resource.encrypt
-      current_resource.encryption_version new_resource.encryption_version
-      if new_resource.secret || new_resource.secret_path
-        current_resource.secret new_secret
-      end
-    end
-  end
-
-  def new_json
-    @new_json ||= begin
-      if new_encrypt
-        # Encrypt new stuff
-        result = encrypt(new_decrypted, new_secret, new_resource.encryption_version)
-      else
-        result = new_decrypted
-      end
-      result
-    end
-  end
-
-  def new_encrypt
-    new_resource.encrypt.nil? ? current_resource.encrypt : new_resource.encrypt
-  end
-
-  def new_secret
-    @new_secret ||= begin
-      if new_resource.secret
-        new_resource.secret
-      elsif new_resource.secret_path
-        Chef::EncryptedDataBagItem.load_secret(new_resource.secret_path)
-      elsif new_resource.encrypt.nil?
-        current_resource.secret
-      else
-        raise "Data bag item #{new_resource.name} has encryption on but no secret or secret_path is specified"
-      end
-    end
-  end
-
-  def decrypt(json, secret)
-    Chef::EncryptedDataBagItem.new(json, secret).to_hash
-  end
-
-  def encrypt(json, secret, version)
-    old_version = run_context.config[:data_bag_encrypt_version]
-    run_context.config[:data_bag_encrypt_version] = version
-    begin
-      Chef::EncryptedDataBagItem.encrypt_data_bag_item(json, secret)
-    ensure
-      run_context.config[:data_bag_encrypt_version] = old_version
-    end
-  end
-
-  # Get the desired (new) json pre-encryption, for comparison purposes
-  def new_decrypted
-    @new_decrypted ||= begin
-      if new_resource.complete
-        result = new_resource.raw_data || {}
-      else
-        result = current_decrypted.merge(new_resource.raw_data || {})
-      end
-      result['id'] = new_resource.id
-      result = apply_modifiers(new_resource.raw_data_modifiers, result)
-    end
-  end
-
-  # Get the current json decrypted, for comparison purposes
-  def current_decrypted
-    @current_decrypted ||= begin
-      if current_resource.secret
-        decrypt(current_resource.raw_data || { 'id' => new_resource.id }, current_resource.secret)
-      elsif current_resource.encrypt
-        raise "Could not decrypt current data bag item #{current_resource.name}"
-      else
-        current_resource.raw_data || { 'id' => new_resource.id }
-      end
-    end
-  end
-
-  # Figure out the differences between new and current
-  def calculate_differences
-    if new_encrypt
-      if current_resource.encrypt
-        # Both are encrypted, check if the encryption type is the same
-        description = ''
-        if new_secret != current_resource.secret
-          description << ' with new secret'
-        end
-        if new_resource.encryption_version != current_resource.encryption_version
-          description << " from v#{current_resource.encryption_version} to v#{new_resource.encryption_version} encryption"
-        end
-
-        if description != ''
-          # Encryption is different, we're reencrypting
-          differences = [ "re-encrypt#{description}"]
         else
-          # Encryption is the same, we're just updating
-          differences = []
+          description = [ "create data bag item #{new_resource.id} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("data/#{new_resource.data_bag}", normalize_for_post(new_json))
+          end
         end
-      else
-        # New stuff should be encrypted, old is not.  Encrypting.
-        differences = [ "encrypt with v#{new_resource.encryption_version} encryption" ]
       end
 
-      # Get differences in the actual json
-      if current_resource.secret
-        json_differences(current_decrypted, new_decrypted, false, '', differences)
-      elsif current_resource.encrypt
-        # Encryption is different and we can't read the old values.  Only allow the change
-        # if we're overwriting the data bag item
-        if !new_resource.complete
-          raise "Cannot encrypt #{new_resource.name} due to failure to decrypt existing resource.  Set 'complete true' to overwrite or add the old secret as old_secret / old_secret_path."
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete data bag item #{new_resource.id} at #{rest.url}" do
+            rest.delete("data/#{new_resource.data_bag}/#{new_resource.id}")
+          end
         end
-        differences = [ "overwrite data bag item (cannot decrypt old data bag item)"]
-        differences = (new_resource.raw_data.keys & current_resource.raw_data.keys).map { |key| "overwrite #{key}"}
-        differences += (new_resource.raw_data.keys - current_resource.raw_data.keys).map { |key| "add #{key}"}
-        differences += (current_resource.raw_data.keys - new_resource.raw_data.keys).map { |key| "remove #{key}" }
-      else
-        json_differences(current_decrypted, new_decrypted, false, '', differences)
       end
-    else
-      if current_resource.encrypt
-        # New stuff should not be encrypted, old is.  Decrypting.
-        differences = [ "decrypt data bag item to plaintext" ]
-      else
-        differences = []
+
+      def load_current_resource
+        begin
+          json = rest.get("data/#{new_resource.data_bag}/#{new_resource.id}")
+          resource = Chef::Resource::ChefDataBagItem.new(new_resource.name, run_context)
+          resource.raw_data json
+          @current_resource = resource
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+
+        # Determine if data bag is encrypted and if so, what its version is
+        first_real_key, first_real_value = (current_resource.raw_data || {}).select { |key, value| key != 'id' && !value.nil? }.first
+        if first_real_value
+          if first_real_value.is_a?(Hash) &&
+             first_real_value['version'].is_a?(Integer) &&
+             first_real_value['version'] > 0 &&
+             first_real_value.has_key?('encrypted_data')
+
+            current_resource.encrypt true
+            current_resource.encryption_version first_real_value['version']
+
+            decrypt_error = nil
+
+            # Check if the desired secret is the one (which it generally should be)
+
+            if new_resource.secret || new_resource.secret_path
+              begin
+                Chef::EncryptedDataBagItem::Decryptor.for(first_real_value, new_secret).for_decrypted_item
+                current_resource.secret new_secret
+              rescue Chef::EncryptedDataBagItem::DecryptionFailure
+                decrypt_error = $!
+              end
+            end
+
+            # If the current secret doesn't work, look through the specified old secrets
+
+            if !current_resource.secret
+              old_secrets = []
+              if new_resource.old_secret
+                old_secrets += Array(new_resource.old_secret)
+              end
+              if new_resource.old_secret_path
+                old_secrets += Array(new_resource.old_secret_path).map do |secret_path|
+                  Chef::EncryptedDataBagItem.load_secret(new_resource.old_secret_file)
+                end
+              end
+              old_secrets.each do |secret|
+                begin
+                  Chef::EncryptedDataBagItem::Decryptor.for(first_real_value, secret).for_decrypted_item
+                  current_resource.secret secret
+                rescue Chef::EncryptedDataBagItem::DecryptionFailure
+                  decrypt_error = $!
+                end
+              end
+
+              # If we couldn't figure out the secret, emit a warning (this isn't a fatal flaw unless we
+              # need to reuse one of the values from the data bag)
+              if !current_resource.secret
+                if decrypt_error
+                  Chef::Log.warn "Existing data bag is encrypted, but could not decrypt: #{decrypt_error.message}."
+                else
+                  Chef::Log.warn "Existing data bag is encrypted, but no secret was specified."
+                end
+              end
+            end
+          end
+        else
+
+          # There are no encryptable values, so pretend encryption is the same as desired
+
+          current_resource.encrypt new_resource.encrypt
+          current_resource.encryption_version new_resource.encryption_version
+          if new_resource.secret || new_resource.secret_path
+            current_resource.secret new_secret
+          end
+        end
       end
-      json_differences(current_decrypted, new_decrypted, true, '', differences)
+
+      def new_json
+        @new_json ||= begin
+          if new_encrypt
+            # Encrypt new stuff
+            result = encrypt(new_decrypted, new_secret, new_resource.encryption_version)
+          else
+            result = new_decrypted
+          end
+          result
+        end
+      end
+
+      def new_encrypt
+        new_resource.encrypt.nil? ? current_resource.encrypt : new_resource.encrypt
+      end
+
+      def new_secret
+        @new_secret ||= begin
+          if new_resource.secret
+            new_resource.secret
+          elsif new_resource.secret_path
+            Chef::EncryptedDataBagItem.load_secret(new_resource.secret_path)
+          elsif new_resource.encrypt.nil?
+            current_resource.secret
+          else
+            raise "Data bag item #{new_resource.name} has encryption on but no secret or secret_path is specified"
+          end
+        end
+      end
+
+      def decrypt(json, secret)
+        Chef::EncryptedDataBagItem.new(json, secret).to_hash
+      end
+
+      def encrypt(json, secret, version)
+        old_version = run_context.config[:data_bag_encrypt_version]
+        run_context.config[:data_bag_encrypt_version] = version
+        begin
+          Chef::EncryptedDataBagItem.encrypt_data_bag_item(json, secret)
+        ensure
+          run_context.config[:data_bag_encrypt_version] = old_version
+        end
+      end
+
+      # Get the desired (new) json pre-encryption, for comparison purposes
+      def new_decrypted
+        @new_decrypted ||= begin
+          if new_resource.complete
+            result = new_resource.raw_data || {}
+          else
+            result = current_decrypted.merge(new_resource.raw_data || {})
+          end
+          result['id'] = new_resource.id
+          result = apply_modifiers(new_resource.raw_data_modifiers, result)
+        end
+      end
+
+      # Get the current json decrypted, for comparison purposes
+      def current_decrypted
+        @current_decrypted ||= begin
+          if current_resource.secret
+            decrypt(current_resource.raw_data || { 'id' => new_resource.id }, current_resource.secret)
+          elsif current_resource.encrypt
+            raise "Could not decrypt current data bag item #{current_resource.name}"
+          else
+            current_resource.raw_data || { 'id' => new_resource.id }
+          end
+        end
+      end
+
+      # Figure out the differences between new and current
+      def calculate_differences
+        if new_encrypt
+          if current_resource.encrypt
+            # Both are encrypted, check if the encryption type is the same
+            description = ''
+            if new_secret != current_resource.secret
+              description << ' with new secret'
+            end
+            if new_resource.encryption_version != current_resource.encryption_version
+              description << " from v#{current_resource.encryption_version} to v#{new_resource.encryption_version} encryption"
+            end
+
+            if description != ''
+              # Encryption is different, we're reencrypting
+              differences = [ "re-encrypt#{description}"]
+            else
+              # Encryption is the same, we're just updating
+              differences = []
+            end
+          else
+            # New stuff should be encrypted, old is not.  Encrypting.
+            differences = [ "encrypt with v#{new_resource.encryption_version} encryption" ]
+          end
+
+          # Get differences in the actual json
+          if current_resource.secret
+            json_differences(current_decrypted, new_decrypted, false, '', differences)
+          elsif current_resource.encrypt
+            # Encryption is different and we can't read the old values.  Only allow the change
+            # if we're overwriting the data bag item
+            if !new_resource.complete
+              raise "Cannot encrypt #{new_resource.name} due to failure to decrypt existing resource.  Set 'complete true' to overwrite or add the old secret as old_secret / old_secret_path."
+            end
+            differences = [ "overwrite data bag item (cannot decrypt old data bag item)"]
+            differences = (new_resource.raw_data.keys & current_resource.raw_data.keys).map { |key| "overwrite #{key}"}
+            differences += (new_resource.raw_data.keys - current_resource.raw_data.keys).map { |key| "add #{key}"}
+            differences += (current_resource.raw_data.keys - new_resource.raw_data.keys).map { |key| "remove #{key}" }
+          else
+            json_differences(current_decrypted, new_decrypted, false, '', differences)
+          end
+        else
+          if current_resource.encrypt
+            # New stuff should not be encrypted, old is.  Decrypting.
+            differences = [ "decrypt data bag item to plaintext" ]
+          else
+            differences = []
+          end
+          json_differences(current_decrypted, new_decrypted, true, '', differences)
+        end
+        differences
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefDataBagItem
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::DataBagItemDataHandler.new
+      end
+
+      def keys
+        {
+          'id' => :id,
+          'data_bag' => :data_bag,
+          'raw_data' => :raw_data
+        }
+      end
+
+      def not_found_resource
+        resource = super
+        resource.data_bag new_resource.data_bag
+        resource
+      end
+
+      def fake_entry
+        FakeEntry.new("#{new_resource.id}.json", FakeEntry.new(new_resource.data_bag))
+      end
+
     end
-    differences
   end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefDataBagItem
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::DataBagItemDataHandler.new
-  end
-
-  def keys
-    {
-      'id' => :id,
-      'data_bag' => :data_bag,
-      'raw_data' => :raw_data
-    }
-  end
-
-  def not_found_resource
-    resource = super
-    resource.data_bag new_resource.data_bag
-    resource
-  end
-
-  def fake_entry
-    FakeEntry.new("#{new_resource.id}.json", FakeEntry.new(new_resource.data_bag))
-  end
-
-end
-end
 end

--- a/lib/chef/provider/chef_environment.rb
+++ b/lib/chef/provider/chef_environment.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_environment'
 require 'chef/chef_fs/data_handler/environment_data_handler'
 
-class Chef::Provider::ChefEnvironment < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefEnvironment < Cheffish::ChefProviderBase
   provides :chef_environment
 
   def whyrun_supported?
@@ -76,4 +78,6 @@ class Chef::Provider::ChefEnvironment < Cheffish::ChefProviderBase
     }
   end
 
+end
+end
 end

--- a/lib/chef/provider/chef_environment.rb
+++ b/lib/chef/provider/chef_environment.rb
@@ -3,81 +3,81 @@ require 'chef/resource/chef_environment'
 require 'chef/chef_fs/data_handler/environment_data_handler'
 
 class Chef
-class Provider
-class ChefEnvironment < Cheffish::ChefProviderBase
-  provides :chef_environment
+  class Provider
+    class ChefEnvironment < Cheffish::ChefProviderBase
+      provides :chef_environment
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    differences = json_differences(current_json, new_json)
+      action :create do
+        differences = json_differences(current_json, new_json)
 
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update environment #{new_resource.name} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("environments/#{new_resource.name}", normalize_for_put(new_json))
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update environment #{new_resource.name} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("environments/#{new_resource.name}", normalize_for_put(new_json))
+            end
+          end
+        else
+          description = [ "create environment #{new_resource.name} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("environments", normalize_for_post(new_json))
+          end
         end
       end
-    else
-      description = [ "create environment #{new_resource.name} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("environments", normalize_for_post(new_json))
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete environment #{new_resource.name} at #{rest.url}" do
+            rest.delete("environments/#{new_resource.name}")
+          end
+        end
       end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("environments/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      def augment_new_json(json)
+        # Apply modifiers
+        json['default_attributes'] = apply_modifiers(new_resource.default_attribute_modifiers, json['default_attributes'])
+        json['override_attributes'] = apply_modifiers(new_resource.override_attribute_modifiers, json['override_attributes'])
+        json
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefEnvironment
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::EnvironmentDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'description' => :description,
+          'cookbook_versions' => :cookbook_versions,
+          'default_attributes' => :default_attributes,
+          'override_attributes' => :override_attributes
+        }
+      end
+
     end
   end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete environment #{new_resource.name} at #{rest.url}" do
-        rest.delete("environments/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("environments/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  def augment_new_json(json)
-    # Apply modifiers
-    json['default_attributes'] = apply_modifiers(new_resource.default_attribute_modifiers, json['default_attributes'])
-    json['override_attributes'] = apply_modifiers(new_resource.override_attribute_modifiers, json['override_attributes'])
-    json
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefEnvironment
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::EnvironmentDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'description' => :description,
-      'cookbook_versions' => :cookbook_versions,
-      'default_attributes' => :default_attributes,
-      'override_attributes' => :override_attributes
-    }
-  end
-
-end
-end
 end

--- a/lib/chef/provider/chef_group.rb
+++ b/lib/chef/provider/chef_group.rb
@@ -3,81 +3,81 @@ require 'chef/resource/chef_group'
 require 'chef/chef_fs/data_handler/group_data_handler'
 
 class Chef
-class Provider
-class ChefGroup < Cheffish::ChefProviderBase
-  provides :chef_group
+  class Provider
+    class ChefGroup < Cheffish::ChefProviderBase
+      provides :chef_group
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    differences = json_differences(current_json, new_json)
+      action :create do
+        differences = json_differences(current_json, new_json)
 
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update group #{new_resource.name} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("groups/#{new_resource.name}", normalize_for_put(new_json))
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update group #{new_resource.name} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("groups/#{new_resource.name}", normalize_for_put(new_json))
+            end
+          end
+        else
+          description = [ "create group #{new_resource.name} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("groups", normalize_for_post(new_json))
+          end
         end
       end
-    else
-      description = [ "create group #{new_resource.name} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("groups", normalize_for_post(new_json))
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete group #{new_resource.name} at #{rest.url}" do
+            rest.delete("groups/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("groups/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      def augment_new_json(json)
+        # Apply modifiers
+        json['users']   |= new_resource.users
+        json['clients'] |= new_resource.clients
+        json['groups']  |= new_resource.groups
+        json['users']   -= new_resource.remove_users
+        json['clients'] -= new_resource.remove_clients
+        json['groups']  -= new_resource.remove_groups
+        json
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefGroup
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::GroupDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'groupname' => :name
+        }
       end
     end
   end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete group #{new_resource.name} at #{rest.url}" do
-        rest.delete("groups/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("groups/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  def augment_new_json(json)
-    # Apply modifiers
-    json['users']   |= new_resource.users
-    json['clients'] |= new_resource.clients
-    json['groups']  |= new_resource.groups
-    json['users']   -= new_resource.remove_users
-    json['clients'] -= new_resource.remove_clients
-    json['groups']  -= new_resource.remove_groups
-    json
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefGroup
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::GroupDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'groupname' => :name
-    }
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_group.rb
+++ b/lib/chef/provider/chef_group.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_group'
 require 'chef/chef_fs/data_handler/group_data_handler'
 
-class Chef::Provider::ChefGroup < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefGroup < Cheffish::ChefProviderBase
   provides :chef_group
 
   def whyrun_supported?
@@ -76,4 +78,6 @@ class Chef::Provider::ChefGroup < Cheffish::ChefProviderBase
       'groupname' => :name
     }
   end
+end
+end
 end

--- a/lib/chef/provider/chef_mirror.rb
+++ b/lib/chef/provider/chef_mirror.rb
@@ -6,164 +6,164 @@ require 'chef/chef_fs/file_system/chef_server_root_dir'
 require 'chef/chef_fs/file_system/chef_repository_file_system_root_dir'
 
 class Chef
-class Provider
-class ChefMirror < Chef::Provider::LWRPBase
-  provides :chef_mirror
+  class Provider
+    class ChefMirror < Chef::Provider::LWRPBase
+      provides :chef_mirror
 
-  def whyrun_supported?
-    true
-  end
-
-  action :upload do
-    with_modified_config do
-      copy_to(local_fs, remote_fs)
-    end
-  end
-
-  action :download do
-    with_modified_config do
-      copy_to(remote_fs, local_fs)
-    end
-  end
-
-  def with_modified_config
-    # pre-Chef-12 ChefFS reads versioned_cookbooks out of Chef::Config instead of
-    # taking it as an input, so we need to modify it for the duration of copy_to
-    @old_versioned_cookbooks = Chef::Config.versioned_cookbooks
-    # If versioned_cookbooks is explicitly set, set it.
-    if !new_resource.versioned_cookbooks.nil?
-      Chef::Config.versioned_cookbooks = new_resource.versioned_cookbooks
-
-    # If new_resource.chef_repo_path is set, versioned_cookbooks defaults to true.
-    # Otherwise, it stays at its current Chef::Config value.
-    elsif new_resource.chef_repo_path
-      Chef::Config.versioned_cookbooks = true
-    end
-
-    begin
-      yield
-    ensure
-      Chef::Config.versioned_cookbooks = @old_versioned_cookbooks
-    end
-  end
-
-  def copy_to(src_root, dest_root)
-    if new_resource.concurrency && new_resource.concurrency <= 0
-      raise "chef_mirror.concurrency must be above 0!  Was set to #{new_resource.concurrency}"
-    end
-    # Honor concurrency
-    Chef::ChefFS::Parallelizer.threads = (new_resource.concurrency || 10) - 1
-
-    # We don't let the user pass absolute paths; we want to reserve those for
-    # multi-org support (/organizations/foo).
-    if new_resource.path[0] == '/'
-      raise "Absolute paths in chef_mirror not yet supported."
-    end
-    # Copy!
-    path = Chef::ChefFS::FilePattern.new("/#{new_resource.path}")
-    ui = CopyListener.new(self)
-    error = Chef::ChefFS::FileSystem.copy_to(path, src_root, dest_root, nil, options, ui, proc { |p| p.path })
-
-    if error
-      raise "Errors while copying:#{ui.errors.map { |e| "#{e}\n" }.join('')}"
-    end
-  end
-
-  def local_fs
-    # If chef_repo_path is set to a string, put it in the form it usually is in
-    # chef config (:chef_repo_path, :node_path, etc.)
-    path_config = new_resource.chef_repo_path
-    if path_config.is_a?(Hash)
-      chef_repo_path = path_config.delete(:chef_repo_path)
-    elsif path_config
-      chef_repo_path = path_config
-      path_config = {}
-    else
-      chef_repo_path = Chef::Config.chef_repo_path
-      path_config = Chef::Config
-    end
-    chef_repo_path = Array(chef_repo_path).flatten
-
-    # Go through the expected object paths and figure out the local paths for each.
-    case repo_mode
-    when 'hosted_everything'
-      object_names = %w(acls clients cookbooks containers data_bags environments groups nodes roles)
-    else
-      object_names = %w(clients cookbooks data_bags environments nodes roles users)
-    end
-
-    object_paths = {}
-    object_names.each do |object_name|
-      variable_name = "#{object_name[0..-2]}_path" # cookbooks -> cookbook_path
-      if path_config[variable_name.to_sym]
-        paths = Array(path_config[variable_name.to_sym]).flatten
-      else
-        paths = chef_repo_path.map { |path| ::File.join(path, object_name) }
+      def whyrun_supported?
+        true
       end
-      object_paths[object_name] = paths.map { |path| ::File.expand_path(path) }
-    end
 
-    # Set up the root dir
-    Chef::ChefFS::FileSystem::ChefRepositoryFileSystemRootDir.new(object_paths)
-  end
+      action :upload do
+        with_modified_config do
+          copy_to(local_fs, remote_fs)
+        end
+      end
 
-  def remote_fs
-    config = {
-      :chef_server_url => new_resource.chef_server[:chef_server_url],
-      :node_name => new_resource.chef_server[:options][:client_name],
-      :client_key => new_resource.chef_server[:options][:signing_key_filename],
-      :repo_mode => repo_mode,
-      :versioned_cookbooks => Chef::Config.versioned_cookbooks
-    }
-    Chef::ChefFS::FileSystem::ChefServerRootDir.new("remote", config)
-  end
+      action :download do
+        with_modified_config do
+          copy_to(remote_fs, local_fs)
+        end
+      end
 
-  def repo_mode
-    new_resource.chef_server[:chef_server_url] =~ /\/organizations\// ? 'hosted_everything' : 'everything'
-  end
+      def with_modified_config
+        # pre-Chef-12 ChefFS reads versioned_cookbooks out of Chef::Config instead of
+        # taking it as an input, so we need to modify it for the duration of copy_to
+        @old_versioned_cookbooks = Chef::Config.versioned_cookbooks
+        # If versioned_cookbooks is explicitly set, set it.
+        if !new_resource.versioned_cookbooks.nil?
+          Chef::Config.versioned_cookbooks = new_resource.versioned_cookbooks
 
-  def options
-    result = {
-      :purge => new_resource.purge,
-      :freeze => new_resource.freeze,
-      :diff => new_resource.no_diff,
-      :dry_run => whyrun_mode?
-    }
-    result[:diff] = !result[:diff]
-    result[:repo_mode] = repo_mode
-    result[:concurrency] = new_resource.concurrency if new_resource.concurrency
-    result
-  end
+        # If new_resource.chef_repo_path is set, versioned_cookbooks defaults to true.
+        # Otherwise, it stays at its current Chef::Config value.
+        elsif new_resource.chef_repo_path
+          Chef::Config.versioned_cookbooks = true
+        end
 
-  def load_current_resource
-  end
+        begin
+          yield
+        ensure
+          Chef::Config.versioned_cookbooks = @old_versioned_cookbooks
+        end
+      end
 
-  class CopyListener
-    def initialize(mirror)
-      @mirror = mirror
-      @errors = []
-    end
+      def copy_to(src_root, dest_root)
+        if new_resource.concurrency && new_resource.concurrency <= 0
+          raise "chef_mirror.concurrency must be above 0!  Was set to #{new_resource.concurrency}"
+        end
+        # Honor concurrency
+        Chef::ChefFS::Parallelizer.threads = (new_resource.concurrency || 10) - 1
 
-    attr_reader :mirror
-    attr_reader :errors
+        # We don't let the user pass absolute paths; we want to reserve those for
+        # multi-org support (/organizations/foo).
+        if new_resource.path[0] == '/'
+          raise "Absolute paths in chef_mirror not yet supported."
+        end
+        # Copy!
+        path = Chef::ChefFS::FilePattern.new("/#{new_resource.path}")
+        ui = CopyListener.new(self)
+        error = Chef::ChefFS::FileSystem.copy_to(path, src_root, dest_root, nil, options, ui, proc { |p| p.path })
 
-    # TODO output is not *always* indicative of a change.  We may want to give
-    # ChefFS the ability to tell us that info.  For now though, assuming any output
-    # means change is pretty damn close to the truth.
-    def output(str)
-      mirror.converge_by str do
+        if error
+          raise "Errors while copying:#{ui.errors.map { |e| "#{e}\n" }.join('')}"
+        end
+      end
+
+      def local_fs
+        # If chef_repo_path is set to a string, put it in the form it usually is in
+        # chef config (:chef_repo_path, :node_path, etc.)
+        path_config = new_resource.chef_repo_path
+        if path_config.is_a?(Hash)
+          chef_repo_path = path_config.delete(:chef_repo_path)
+        elsif path_config
+          chef_repo_path = path_config
+          path_config = {}
+        else
+          chef_repo_path = Chef::Config.chef_repo_path
+          path_config = Chef::Config
+        end
+        chef_repo_path = Array(chef_repo_path).flatten
+
+        # Go through the expected object paths and figure out the local paths for each.
+        case repo_mode
+        when 'hosted_everything'
+          object_names = %w(acls clients cookbooks containers data_bags environments groups nodes roles)
+        else
+          object_names = %w(clients cookbooks data_bags environments nodes roles users)
+        end
+
+        object_paths = {}
+        object_names.each do |object_name|
+          variable_name = "#{object_name[0..-2]}_path" # cookbooks -> cookbook_path
+          if path_config[variable_name.to_sym]
+            paths = Array(path_config[variable_name.to_sym]).flatten
+          else
+            paths = chef_repo_path.map { |path| ::File.join(path, object_name) }
+          end
+          object_paths[object_name] = paths.map { |path| ::File.expand_path(path) }
+        end
+
+        # Set up the root dir
+        Chef::ChefFS::FileSystem::ChefRepositoryFileSystemRootDir.new(object_paths)
+      end
+
+      def remote_fs
+        config = {
+          :chef_server_url => new_resource.chef_server[:chef_server_url],
+          :node_name => new_resource.chef_server[:options][:client_name],
+          :client_key => new_resource.chef_server[:options][:signing_key_filename],
+          :repo_mode => repo_mode,
+          :versioned_cookbooks => Chef::Config.versioned_cookbooks
+        }
+        Chef::ChefFS::FileSystem::ChefServerRootDir.new("remote", config)
+      end
+
+      def repo_mode
+        new_resource.chef_server[:chef_server_url] =~ /\/organizations\// ? 'hosted_everything' : 'everything'
+      end
+
+      def options
+        result = {
+          :purge => new_resource.purge,
+          :freeze => new_resource.freeze,
+          :diff => new_resource.no_diff,
+          :dry_run => whyrun_mode?
+        }
+        result[:diff] = !result[:diff]
+        result[:repo_mode] = repo_mode
+        result[:concurrency] = new_resource.concurrency if new_resource.concurrency
+        result
+      end
+
+      def load_current_resource
+      end
+
+      class CopyListener
+        def initialize(mirror)
+          @mirror = mirror
+          @errors = []
+        end
+
+        attr_reader :mirror
+        attr_reader :errors
+
+        # TODO output is not *always* indicative of a change.  We may want to give
+        # ChefFS the ability to tell us that info.  For now though, assuming any output
+        # means change is pretty damn close to the truth.
+        def output(str)
+          mirror.converge_by str do
+          end
+        end
+        def warn(str)
+          mirror.converge_by "WARNING: #{str}" do
+          end
+        end
+        def error(str)
+          mirror.converge_by "ERROR: #{str}" do
+          end
+          @errors << str
+        end
       end
     end
-    def warn(str)
-      mirror.converge_by "WARNING: #{str}" do
-      end
-    end
-    def error(str)
-      mirror.converge_by "ERROR: #{str}" do
-      end
-      @errors << str
-    end
   end
-end
-end
 end

--- a/lib/chef/provider/chef_mirror.rb
+++ b/lib/chef/provider/chef_mirror.rb
@@ -5,7 +5,9 @@ require 'chef/chef_fs/parallelizer'
 require 'chef/chef_fs/file_system/chef_server_root_dir'
 require 'chef/chef_fs/file_system/chef_repository_file_system_root_dir'
 
-class Chef::Provider::ChefMirror < Chef::Provider::LWRPBase
+class Chef
+class Provider
+class ChefMirror < Chef::Provider::LWRPBase
   provides :chef_mirror
 
   def whyrun_supported?
@@ -162,4 +164,6 @@ class Chef::Provider::ChefMirror < Chef::Provider::LWRPBase
       @errors << str
     end
   end
+end
+end
 end

--- a/lib/chef/provider/chef_node.rb
+++ b/lib/chef/provider/chef_node.rb
@@ -3,85 +3,85 @@ require 'chef/resource/chef_node'
 require 'chef/chef_fs/data_handler/node_data_handler'
 
 class Chef
-class Provider
-class ChefNode < Cheffish::ChefProviderBase
-  provides :chef_node
+  class Provider
+    class ChefNode < Cheffish::ChefProviderBase
+      provides :chef_node
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    differences = json_differences(current_json, new_json)
+      action :create do
+        differences = json_differences(current_json, new_json)
 
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update node #{new_resource.name} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("nodes/#{new_resource.name}", normalize_for_put(new_json))
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update node #{new_resource.name} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("nodes/#{new_resource.name}", normalize_for_put(new_json))
+            end
+          end
+        else
+          description = [ "create node #{new_resource.name} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("nodes", normalize_for_post(new_json))
+          end
         end
       end
-    else
-      description = [ "create node #{new_resource.name} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("nodes", normalize_for_post(new_json))
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete node #{new_resource.name} at #{rest.url}" do
+            rest.delete("nodes/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("nodes/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      def augment_new_json(json)
+        # Preserve tags even if "attributes" was overwritten directly
+        json['normal']['tags'] = current_json['normal']['tags'] unless json['normal']['tags']
+        # Apply modifiers
+        json['run_list'] = apply_run_list_modifiers(new_resource.run_list_modifiers, new_resource.run_list_removers, json['run_list'])
+        json['normal'] = apply_modifiers(new_resource.attribute_modifiers, json['normal'])
+        # Preserve default/override/automatic even when "complete true"
+        json['default'] = current_json['default']
+        json['override'] = current_json['override']
+        json['automatic'] = current_json['automatic']
+        json
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefNode
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::NodeDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'chef_environment' => :chef_environment,
+          'run_list' => :run_list,
+          'normal' => :attributes
+        }
       end
     end
   end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete node #{new_resource.name} at #{rest.url}" do
-        rest.delete("nodes/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("nodes/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  def augment_new_json(json)
-    # Preserve tags even if "attributes" was overwritten directly
-    json['normal']['tags'] = current_json['normal']['tags'] unless json['normal']['tags']
-    # Apply modifiers
-    json['run_list'] = apply_run_list_modifiers(new_resource.run_list_modifiers, new_resource.run_list_removers, json['run_list'])
-    json['normal'] = apply_modifiers(new_resource.attribute_modifiers, json['normal'])
-    # Preserve default/override/automatic even when "complete true"
-    json['default'] = current_json['default']
-    json['override'] = current_json['override']
-    json['automatic'] = current_json['automatic']
-    json
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefNode
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::NodeDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'chef_environment' => :chef_environment,
-      'run_list' => :run_list,
-      'normal' => :attributes
-    }
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_node.rb
+++ b/lib/chef/provider/chef_node.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_node'
 require 'chef/chef_fs/data_handler/node_data_handler'
 
-class Chef::Provider::ChefNode < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefNode < Cheffish::ChefProviderBase
   provides :chef_node
 
   def whyrun_supported?
@@ -80,4 +82,6 @@ class Chef::Provider::ChefNode < Cheffish::ChefProviderBase
       'normal' => :attributes
     }
   end
+end
+end
 end

--- a/lib/chef/provider/chef_organization.rb
+++ b/lib/chef/provider/chef_organization.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_organization'
 require 'chef/chef_fs/data_handler/data_handler_base'
 
-class Chef::Provider::ChefOrganization < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefOrganization < Cheffish::ChefProviderBase
   provides :chef_organization
 
   def whyrun_supported?
@@ -148,4 +150,6 @@ class Chef::Provider::ChefOrganization < Cheffish::ChefProviderBase
       })
     end
   end
+end
+end
 end

--- a/lib/chef/provider/chef_organization.rb
+++ b/lib/chef/provider/chef_organization.rb
@@ -3,153 +3,153 @@ require 'chef/resource/chef_organization'
 require 'chef/chef_fs/data_handler/data_handler_base'
 
 class Chef
-class Provider
-class ChefOrganization < Cheffish::ChefProviderBase
-  provides :chef_organization
+  class Provider
+    class ChefOrganization < Cheffish::ChefProviderBase
+      provides :chef_organization
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    differences = json_differences(current_json, new_json)
+      action :create do
+        differences = json_differences(current_json, new_json)
 
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update organization #{new_resource.name} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("#{rest.root_url}/organizations/#{new_resource.name}", normalize_for_put(new_json))
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update organization #{new_resource.name} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("#{rest.root_url}/organizations/#{new_resource.name}", normalize_for_put(new_json))
+            end
+          end
+        else
+          description = [ "create organization #{new_resource.name} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("#{rest.root_url}/organizations", normalize_for_post(new_json))
+          end
+        end
+
+        # Revoke invites and memberships when asked
+        invites_to_remove.each do |user|
+          if outstanding_invites.has_key?(user)
+            converge_by "revoke #{user}'s invitation to organization #{new_resource.name}" do
+              rest.delete("#{rest.root_url}/organizations/#{new_resource.name}/association_requests/#{outstanding_invites[user]}")
+            end
+          end
+        end
+        members_to_remove.each do |user|
+          if existing_members.include?(user)
+            converge_by "remove #{user} from organization #{new_resource.name}" do
+              rest.delete("#{rest.root_url}/organizations/#{new_resource.name}/users/#{user}")
+            end
+          end
+        end
+
+        # Invite and add members when asked
+        new_resource.invites.each do |user|
+          if !existing_members.include?(user) && !outstanding_invites.has_key?(user)
+            converge_by "invite #{user} to organization #{new_resource.name}" do
+              rest.post("#{rest.root_url}/organizations/#{new_resource.name}/association_requests", { 'user' => user })
+            end
+          end
+        end
+        new_resource.members.each do |user|
+          if !existing_members.include?(user)
+            converge_by "Add #{user} to organization #{new_resource.name}" do
+              rest.post("#{rest.root_url}/organizations/#{new_resource.name}/users/", { 'username' => user })
+            end
+          end
         end
       end
-    else
-      description = [ "create organization #{new_resource.name} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("#{rest.root_url}/organizations", normalize_for_post(new_json))
-      end
-    end
 
-    # Revoke invites and memberships when asked
-    invites_to_remove.each do |user|
-      if outstanding_invites.has_key?(user)
-        converge_by "revoke #{user}'s invitation to organization #{new_resource.name}" do
-          rest.delete("#{rest.root_url}/organizations/#{new_resource.name}/association_requests/#{outstanding_invites[user]}")
+      def existing_members
+        @existing_members ||= rest.get("#{rest.root_url}/organizations/#{new_resource.name}/users").map { |u| u['user']['username'] }
+      end
+
+      def outstanding_invites
+        @outstanding_invites ||= begin
+          invites = {}
+          rest.get("#{rest.root_url}/organizations/#{new_resource.name}/association_requests").each do |r|
+            invites[r['username']] = r['id']
+          end
+          invites
+        end
+      end
+
+      def invites_to_remove
+        if new_resource.complete
+          if new_resource.invites_specified? || new_resource.members_specified?
+            outstanding_invites.keys - (new_resource.invites | new_resource.members)
+          else
+            []
+          end
+        else
+          new_resource.remove_members
+        end
+      end
+
+      def members_to_remove
+        if new_resource.complete
+          if new_resource.members_specified?
+            existing_members - (new_resource.invites | new_resource.members)
+          else
+            []
+          end
+        else
+          new_resource.remove_members
+        end
+      end
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete organization #{new_resource.name} at #{rest.url}" do
+            rest.delete("#{rest.root_url}/organizations/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("#{rest.root_url}/organizations/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefOrganization
+      end
+
+      def data_handler
+        OrganizationDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'full_name' => :full_name
+        }
+      end
+
+      class OrganizationDataHandler < Chef::ChefFS::DataHandler::DataHandlerBase
+        def normalize(organization, entry)
+          # Normalize the order of the keys for easier reading
+          normalize_hash(organization, {
+            'name' => remove_dot_json(entry.name),
+            'full_name' => remove_dot_json(entry.name),
+            'org_type' => 'Business',
+            'clientname' => "#{remove_dot_json(entry.name)}-validator",
+            'billing_plan' => 'platform-free'
+          })
         end
       end
     end
-    members_to_remove.each do |user|
-      if existing_members.include?(user)
-        converge_by "remove #{user} from organization #{new_resource.name}" do
-          rest.delete("#{rest.root_url}/organizations/#{new_resource.name}/users/#{user}")
-        end
-      end
-    end
-
-    # Invite and add members when asked
-    new_resource.invites.each do |user|
-      if !existing_members.include?(user) && !outstanding_invites.has_key?(user)
-        converge_by "invite #{user} to organization #{new_resource.name}" do
-          rest.post("#{rest.root_url}/organizations/#{new_resource.name}/association_requests", { 'user' => user })
-        end
-      end
-    end
-    new_resource.members.each do |user|
-      if !existing_members.include?(user)
-        converge_by "Add #{user} to organization #{new_resource.name}" do
-          rest.post("#{rest.root_url}/organizations/#{new_resource.name}/users/", { 'username' => user })
-        end
-      end
-    end
   end
-
-  def existing_members
-    @existing_members ||= rest.get("#{rest.root_url}/organizations/#{new_resource.name}/users").map { |u| u['user']['username'] }
-  end
-
-  def outstanding_invites
-    @outstanding_invites ||= begin
-      invites = {}
-      rest.get("#{rest.root_url}/organizations/#{new_resource.name}/association_requests").each do |r|
-        invites[r['username']] = r['id']
-      end
-      invites
-    end
-  end
-
-  def invites_to_remove
-    if new_resource.complete
-      if new_resource.invites_specified? || new_resource.members_specified?
-        outstanding_invites.keys - (new_resource.invites | new_resource.members)
-      else
-        []
-      end
-    else
-      new_resource.remove_members
-    end
-  end
-
-  def members_to_remove
-    if new_resource.complete
-      if new_resource.members_specified?
-        existing_members - (new_resource.invites | new_resource.members)
-      else
-        []
-      end
-    else
-      new_resource.remove_members
-    end
-  end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete organization #{new_resource.name} at #{rest.url}" do
-        rest.delete("#{rest.root_url}/organizations/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("#{rest.root_url}/organizations/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefOrganization
-  end
-
-  def data_handler
-    OrganizationDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'full_name' => :full_name
-    }
-  end
-
-  class OrganizationDataHandler < Chef::ChefFS::DataHandler::DataHandlerBase
-    def normalize(organization, entry)
-      # Normalize the order of the keys for easier reading
-      normalize_hash(organization, {
-        'name' => remove_dot_json(entry.name),
-        'full_name' => remove_dot_json(entry.name),
-        'org_type' => 'Business',
-        'clientname' => "#{remove_dot_json(entry.name)}-validator",
-        'billing_plan' => 'platform-free'
-      })
-    end
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_resolved_cookbooks.rb
+++ b/lib/chef/provider/chef_resolved_cookbooks.rb
@@ -2,45 +2,45 @@ require 'chef/provider/lwrp_base'
 require 'chef_zero'
 
 class Chef
-class Provider
-class ChefResolvedCookbooks < Chef::Provider::LWRPBase
-  provides :chef_resolved_cookbooks
+  class Provider
+    class ChefResolvedCookbooks < Chef::Provider::LWRPBase
+      provides :chef_resolved_cookbooks
 
-  action :resolve do
-    new_resource.cookbooks_from.each do |path|
-      ::Dir.entries(path).each do |name|
-        if ::File.directory?(::File.join(path, name)) && name != '.' && name != '..'
-          new_resource.berksfile.cookbook name, :path => ::File.join(path, name)
+      action :resolve do
+        new_resource.cookbooks_from.each do |path|
+          ::Dir.entries(path).each do |name|
+            if ::File.directory?(::File.join(path, name)) && name != '.' && name != '..'
+              new_resource.berksfile.cookbook name, :path => ::File.join(path, name)
+            end
+          end
+        end
+
+        new_resource.berksfile.install
+
+        # Ridley really really wants a key :/
+        if new_resource.chef_server[:options][:signing_key_filename]
+          new_resource.berksfile.upload(
+            :server_url => new_resource.chef_server[:chef_server_url],
+            :client_name => new_resource.chef_server[:options][:client_name],
+            :client_key => new_resource.chef_server[:options][:signing_key_filename])
+        else
+          file = Tempfile.new('privatekey')
+          begin
+            file.write(ChefZero::PRIVATE_KEY)
+            file.close
+
+            new_resource.berksfile.upload(
+              :server_url => new_resource.chef_server[:chef_server_url],
+              :client_name => new_resource.chef_server[:options][:client_name] || 'me',
+              :client_key => file.path)
+
+          ensure
+            file.close
+            file.unlink
+          end
         end
       end
-    end
 
-    new_resource.berksfile.install
-
-    # Ridley really really wants a key :/
-    if new_resource.chef_server[:options][:signing_key_filename]
-      new_resource.berksfile.upload(
-        :server_url => new_resource.chef_server[:chef_server_url],
-        :client_name => new_resource.chef_server[:options][:client_name],
-        :client_key => new_resource.chef_server[:options][:signing_key_filename])
-    else
-      file = Tempfile.new('privatekey')
-      begin
-        file.write(ChefZero::PRIVATE_KEY)
-        file.close
-
-        new_resource.berksfile.upload(
-          :server_url => new_resource.chef_server[:chef_server_url],
-          :client_name => new_resource.chef_server[:options][:client_name] || 'me',
-          :client_key => file.path)
-
-      ensure
-        file.close
-        file.unlink
-      end
     end
   end
-
-end
-end
 end

--- a/lib/chef/provider/chef_resolved_cookbooks.rb
+++ b/lib/chef/provider/chef_resolved_cookbooks.rb
@@ -1,7 +1,9 @@
 require 'chef/provider/lwrp_base'
 require 'chef_zero'
 
-class Chef::Provider::ChefResolvedCookbooks < Chef::Provider::LWRPBase
+class Chef
+class Provider
+class ChefResolvedCookbooks < Chef::Provider::LWRPBase
   provides :chef_resolved_cookbooks
 
   action :resolve do
@@ -39,4 +41,6 @@ class Chef::Provider::ChefResolvedCookbooks < Chef::Provider::LWRPBase
     end
   end
 
+end
+end
 end

--- a/lib/chef/provider/chef_role.rb
+++ b/lib/chef/provider/chef_role.rb
@@ -3,82 +3,82 @@ require 'chef/resource/chef_role'
 require 'chef/chef_fs/data_handler/role_data_handler'
 
 class Chef
-class Provider
-class ChefRole < Cheffish::ChefProviderBase
-  provides :chef_role
+  class Provider
+    class ChefRole < Cheffish::ChefProviderBase
+      provides :chef_role
 
-  def whyrun_supported?
-    true
-  end
+      def whyrun_supported?
+        true
+      end
 
-  action :create do
-    differences = json_differences(current_json, new_json)
+      action :create do
+        differences = json_differences(current_json, new_json)
 
-    if current_resource_exists?
-      if differences.size > 0
-        description = [ "update role #{new_resource.name} at #{rest.url}" ] + differences
-        converge_by description do
-          rest.put("roles/#{new_resource.name}", normalize_for_put(new_json))
+        if current_resource_exists?
+          if differences.size > 0
+            description = [ "update role #{new_resource.name} at #{rest.url}" ] + differences
+            converge_by description do
+              rest.put("roles/#{new_resource.name}", normalize_for_put(new_json))
+            end
+          end
+        else
+          description = [ "create role #{new_resource.name} at #{rest.url}" ] + differences
+          converge_by description do
+            rest.post("roles", normalize_for_post(new_json))
+          end
         end
       end
-    else
-      description = [ "create role #{new_resource.name} at #{rest.url}" ] + differences
-      converge_by description do
-        rest.post("roles", normalize_for_post(new_json))
+
+      action :delete do
+        if current_resource_exists?
+          converge_by "delete role #{new_resource.name} at #{rest.url}" do
+            rest.delete("roles/#{new_resource.name}")
+          end
+        end
+      end
+
+      def load_current_resource
+        begin
+          @current_resource = json_to_resource(rest.get("roles/#{new_resource.name}"))
+        rescue Net::HTTPServerException => e
+          if e.response.code == "404"
+            @current_resource = not_found_resource
+          else
+            raise
+          end
+        end
+      end
+
+      def augment_new_json(json)
+        # Apply modifiers
+        json['run_list'] = apply_run_list_modifiers(new_resource.run_list_modifiers, new_resource.run_list_removers, json['run_list'])
+        json['default_attributes'] = apply_modifiers(new_resource.default_attribute_modifiers, json['default_attributes'])
+        json['override_attributes'] = apply_modifiers(new_resource.override_attribute_modifiers, json['override_attributes'])
+        json
+      end
+
+      #
+      # Helpers
+      #
+
+      def resource_class
+        Chef::Resource::ChefRole
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::RoleDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'description' => :description,
+          'run_list' => :run_list,
+          'env_run_lists' => :env_run_lists,
+          'default_attributes' => :default_attributes,
+          'override_attributes' => :override_attributes
+        }
       end
     end
   end
-
-  action :delete do
-    if current_resource_exists?
-      converge_by "delete role #{new_resource.name} at #{rest.url}" do
-        rest.delete("roles/#{new_resource.name}")
-      end
-    end
-  end
-
-  def load_current_resource
-    begin
-      @current_resource = json_to_resource(rest.get("roles/#{new_resource.name}"))
-    rescue Net::HTTPServerException => e
-      if e.response.code == "404"
-        @current_resource = not_found_resource
-      else
-        raise
-      end
-    end
-  end
-
-  def augment_new_json(json)
-    # Apply modifiers
-    json['run_list'] = apply_run_list_modifiers(new_resource.run_list_modifiers, new_resource.run_list_removers, json['run_list'])
-    json['default_attributes'] = apply_modifiers(new_resource.default_attribute_modifiers, json['default_attributes'])
-    json['override_attributes'] = apply_modifiers(new_resource.override_attribute_modifiers, json['override_attributes'])
-    json
-  end
-
-  #
-  # Helpers
-  #
-
-  def resource_class
-    Chef::Resource::ChefRole
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::RoleDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'description' => :description,
-      'run_list' => :run_list,
-      'env_run_lists' => :env_run_lists,
-      'default_attributes' => :default_attributes,
-      'override_attributes' => :override_attributes
-    }
-  end
-end
-end
 end

--- a/lib/chef/provider/chef_role.rb
+++ b/lib/chef/provider/chef_role.rb
@@ -2,7 +2,9 @@ require 'cheffish/chef_provider_base'
 require 'chef/resource/chef_role'
 require 'chef/chef_fs/data_handler/role_data_handler'
 
-class Chef::Provider::ChefRole < Cheffish::ChefProviderBase
+class Chef
+class Provider
+class ChefRole < Cheffish::ChefProviderBase
   provides :chef_role
 
   def whyrun_supported?
@@ -77,4 +79,6 @@ class Chef::Provider::ChefRole < Cheffish::ChefProviderBase
       'override_attributes' => :override_attributes
     }
   end
+end
+end
 end

--- a/lib/chef/provider/chef_user.rb
+++ b/lib/chef/provider/chef_user.rb
@@ -2,7 +2,9 @@ require 'cheffish/actor_provider_base'
 require 'chef/resource/chef_user'
 require 'chef/chef_fs/data_handler/user_data_handler'
 
-class Chef::Provider::ChefUser < Cheffish::ActorProviderBase
+class Chef
+class Provider
+class ChefUser < Cheffish::ActorProviderBase
   provides :chef_user
 
   def whyrun_supported?
@@ -52,4 +54,6 @@ class Chef::Provider::ChefUser < Cheffish::ActorProviderBase
     }
   end
 
+end
+end
 end

--- a/lib/chef/provider/chef_user.rb
+++ b/lib/chef/provider/chef_user.rb
@@ -3,57 +3,57 @@ require 'chef/resource/chef_user'
 require 'chef/chef_fs/data_handler/user_data_handler'
 
 class Chef
-class Provider
-class ChefUser < Cheffish::ActorProviderBase
-  provides :chef_user
+  class Provider
+    class ChefUser < Cheffish::ActorProviderBase
+      provides :chef_user
 
-  def whyrun_supported?
-    true
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        create_actor
+      end
+
+      action :delete do
+        delete_actor
+      end
+
+      #
+      # Helpers
+      #
+      # Gives us new_json, current_json, not_found_json, etc.
+
+      def actor_type
+        'user'
+      end
+
+      def actor_path
+        "#{rest.root_url}/users"
+      end
+
+      def resource_class
+        Chef::Resource::ChefUser
+      end
+
+      def data_handler
+        Chef::ChefFS::DataHandler::UserDataHandler.new
+      end
+
+      def keys
+        {
+          'name' => :name,
+          'username' => :name,
+          'display_name' => :display_name,
+          'admin' => :admin,
+          'email' => :email,
+          'password' => :password,
+          'external_authentication_uid' => :external_authentication_uid,
+          'recovery_authentication_enabled' => :recovery_authentication_enabled,
+          'public_key' => :source_key
+        }
+      end
+
+    end
   end
-
-  action :create do
-    create_actor
-  end
-
-  action :delete do
-    delete_actor
-  end
-
-  #
-  # Helpers
-  #
-  # Gives us new_json, current_json, not_found_json, etc.
-
-  def actor_type
-    'user'
-  end
-
-  def actor_path
-    "#{rest.root_url}/users"
-  end
-
-  def resource_class
-    Chef::Resource::ChefUser
-  end
-
-  def data_handler
-    Chef::ChefFS::DataHandler::UserDataHandler.new
-  end
-
-  def keys
-    {
-      'name' => :name,
-      'username' => :name,
-      'display_name' => :display_name,
-      'admin' => :admin,
-      'email' => :email,
-      'password' => :password,
-      'external_authentication_uid' => :external_authentication_uid,
-      'recovery_authentication_enabled' => :recovery_authentication_enabled,
-      'public_key' => :source_key
-    }
-  end
-
-end
-end
 end

--- a/lib/chef/provider/private_key.rb
+++ b/lib/chef/provider/private_key.rb
@@ -3,223 +3,223 @@ require 'openssl'
 require 'cheffish/key_formatter'
 
 class Chef
-class Provider
-class PrivateKey < Chef::Provider::LWRPBase
-  provides :private_key
+  class Provider
+    class PrivateKey < Chef::Provider::LWRPBase
+      provides :private_key
 
-  action :create do
-    create_key(false, :create)
-  end
-
-  action :regenerate do
-    create_key(true, :regenerate)
-  end
-
-  action :delete do
-    if current_resource.path
-      converge_by "delete private key #{new_path}" do
-        ::File.unlink(new_path)
-      end
-    end
-  end
-
-  use_inline_resources
-
-  def whyrun_supported?
-    true
-  end
-
-  def create_key(regenerate, action)
-    if @should_create_directory
-      Cheffish.inline_resource(self, action) do
-        directory run_context.config[:private_key_write_path]
-      end
-    end
-
-    final_private_key = nil
-    if new_source_key
-      #
-      # Create private key from source
-      #
-      desired_output = encode_private_key(new_source_key)
-      if current_resource.path == :none || desired_output != IO.read(new_path)
-        converge_by "reformat key at #{new_resource.source_key_path} to #{new_resource.format} private key #{new_path} (#{new_resource.pass_phrase ? ", #{new_resource.cipher} password" : ""})" do
-          IO.write(new_path, desired_output)
-        end
+      action :create do
+        create_key(false, :create)
       end
 
-      final_private_key = new_source_key
+      action :regenerate do
+        create_key(true, :regenerate)
+      end
 
-    else
-      #
-      # Generate a new key
-      #
-      if current_resource.action == [ :delete ] || regenerate ||
-        (new_resource.regenerate_if_different &&
-          (!current_private_key ||
-           current_resource.size != new_resource.size ||
-           current_resource.type != new_resource.type))
-
-       case new_resource.type
-        when :rsa
-          if new_resource.exponent
-            final_private_key = OpenSSL::PKey::RSA.generate(new_resource.size, new_resource.exponent)
-          else
-            final_private_key = OpenSSL::PKey::RSA.generate(new_resource.size)
+      action :delete do
+        if current_resource.path
+          converge_by "delete private key #{new_path}" do
+            ::File.unlink(new_path)
           end
-        when :dsa
-          final_private_key = OpenSSL::PKey::DSA.generate(new_resource.size)
         end
-
-        generated_key = true
-      elsif !current_private_key
-        raise "Could not read private key from #{current_resource.path}: missing pass phrase?"
-      else
-        final_private_key = current_private_key
-        generated_key = false
       end
 
-      if generated_key
-        generated_description = " (#{new_resource.size} bits#{new_resource.pass_phrase ? ", #{new_resource.cipher} password" : ""})"
+      use_inline_resources
 
-        if new_path != :none
-          action = current_resource.path == :none ? 'create' : 'overwrite'
-          converge_by "#{action} #{new_resource.type} private key #{new_path}#{generated_description}" do
-            write_private_key(final_private_key)
+      def whyrun_supported?
+        true
+      end
+
+      def create_key(regenerate, action)
+        if @should_create_directory
+          Cheffish.inline_resource(self, action) do
+            directory run_context.config[:private_key_write_path]
+          end
+        end
+
+        final_private_key = nil
+        if new_source_key
+          #
+          # Create private key from source
+          #
+          desired_output = encode_private_key(new_source_key)
+          if current_resource.path == :none || desired_output != IO.read(new_path)
+            converge_by "reformat key at #{new_resource.source_key_path} to #{new_resource.format} private key #{new_path} (#{new_resource.pass_phrase ? ", #{new_resource.cipher} password" : ""})" do
+              IO.write(new_path, desired_output)
+            end
+          end
+
+          final_private_key = new_source_key
+
+        else
+          #
+          # Generate a new key
+          #
+          if current_resource.action == [ :delete ] || regenerate ||
+            (new_resource.regenerate_if_different &&
+              (!current_private_key ||
+               current_resource.size != new_resource.size ||
+               current_resource.type != new_resource.type))
+
+           case new_resource.type
+            when :rsa
+              if new_resource.exponent
+                final_private_key = OpenSSL::PKey::RSA.generate(new_resource.size, new_resource.exponent)
+              else
+                final_private_key = OpenSSL::PKey::RSA.generate(new_resource.size)
+              end
+            when :dsa
+              final_private_key = OpenSSL::PKey::DSA.generate(new_resource.size)
+            end
+
+            generated_key = true
+          elsif !current_private_key
+            raise "Could not read private key from #{current_resource.path}: missing pass phrase?"
+          else
+            final_private_key = current_private_key
+            generated_key = false
+          end
+
+          if generated_key
+            generated_description = " (#{new_resource.size} bits#{new_resource.pass_phrase ? ", #{new_resource.cipher} password" : ""})"
+
+            if new_path != :none
+              action = current_resource.path == :none ? 'create' : 'overwrite'
+              converge_by "#{action} #{new_resource.type} private key #{new_path}#{generated_description}" do
+                write_private_key(final_private_key)
+              end
+            else
+              converge_by "generate private key#{generated_description}" do
+              end
+            end
+          else
+            # Warn if existing key has different characteristics than expected
+            if current_resource.size != new_resource.size
+              Chef::Log.warn("Mismatched key size!  #{current_resource.path} is #{current_resource.size} bytes, desired is #{new_resource.size} bytes.  Use action :regenerate to force key regeneration.")
+            elsif current_resource.type != new_resource.type
+              Chef::Log.warn("Mismatched key type!  #{current_resource.path} is #{current_resource.type}, desired is #{new_resource.type} bytes.  Use action :regenerate to force key regeneration.")
+            end
+
+            if current_resource.format != new_resource.format
+              converge_by "change format of #{new_resource.type} private key #{new_path} from #{current_resource.format} to #{new_resource.format}" do
+                write_private_key(current_private_key)
+              end
+            elsif (@current_file_mode & 0077) != 0
+              new_mode = @current_file_mode & 07700
+              converge_by "change mode of private key #{new_path} to #{new_mode.to_s(8)}" do
+                ::File.chmod(new_mode, new_path)
+              end
+            end
+          end
+        end
+
+        if new_resource.public_key_path
+          public_key_path = new_resource.public_key_path
+          public_key_format = new_resource.public_key_format
+          Cheffish.inline_resource(self, action) do
+            public_key public_key_path do
+              source_key final_private_key
+              format public_key_format
+            end
+          end
+        end
+
+        if new_resource.after
+          new_resource.after.call(new_resource, final_private_key)
+        end
+      end
+
+      def encode_private_key(key)
+        key_format = {}
+        key_format[:format] = new_resource.format if new_resource.format
+        key_format[:pass_phrase] = new_resource.pass_phrase if new_resource.pass_phrase
+        key_format[:cipher] = new_resource.cipher if new_resource.cipher
+        Cheffish::KeyFormatter.encode(key, key_format)
+      end
+
+      def write_private_key(key)
+        ::File.open(new_path, 'w') do |file|
+          file.chmod(0600)
+          file.write(encode_private_key(key))
+        end
+      end
+
+      def new_source_key
+        @new_source_key ||= begin
+          if new_resource.source_key.is_a?(String)
+            source_key, source_key_format = Cheffish::KeyFormatter.decode(new_resource.source_key, new_resource.source_key_pass_phrase)
+            source_key
+          elsif new_resource.source_key
+            new_resource.source_key
+          elsif new_resource.source_key_path
+            source_key, source_key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.source_key_path), new_resource.source_key_pass_phrase, new_resource.source_key_path)
+            source_key
+          else
+            nil
+          end
+        end
+      end
+
+      attr_reader :current_private_key
+
+      def new_path
+        new_key_with_path[1]
+      end
+
+      def new_key_with_path
+        path = new_resource.path
+        if path.is_a?(Symbol)
+          return [ nil, path ]
+        elsif Pathname.new(path).relative?
+          private_key, private_key_path = Cheffish.get_private_key_with_path(path, run_context.config)
+          if private_key
+            return [ private_key, (private_key_path || :none) ]
+          elsif run_context.config[:private_key_write_path]
+            @should_create_directory = true
+            path = ::File.join(run_context.config[:private_key_write_path], path)
+            return [ nil, path ]
+          else
+            raise "Could not find key #{path} and Chef::Config.private_key_write_path is not set."
+          end
+        elsif ::File.exist?(path)
+          return [ IO.read(path), path ]
+        else
+          return [ nil, path ]
+        end
+      end
+
+      def load_current_resource
+        resource = Chef::Resource::PrivateKey.new(new_resource.name, run_context)
+
+        new_key, new_path = new_key_with_path
+        if new_path != :none && ::File.exist?(new_path)
+          resource.path new_path
+          @current_file_mode = ::File.stat(new_path).mode
+        else
+          resource.path :none
+        end
+
+        if new_key
+          begin
+            key, key_format = Cheffish::KeyFormatter.decode(new_key, new_resource.pass_phrase, new_path)
+            if key
+              @current_private_key = key
+              resource.format key_format[:format]
+              resource.type key_format[:type]
+              resource.size key_format[:size]
+              resource.exponent key_format[:exponent]
+              resource.pass_phrase key_format[:pass_phrase]
+              resource.cipher key_format[:cipher]
+            end
+          rescue
+            # If there's an error reading, we assume format and type are wrong and don't futz with them
+            Chef::Log.warn("Error reading #{new_path}: #{$!}")
           end
         else
-          converge_by "generate private key#{generated_description}" do
-          end
-        end
-      else
-        # Warn if existing key has different characteristics than expected
-        if current_resource.size != new_resource.size
-          Chef::Log.warn("Mismatched key size!  #{current_resource.path} is #{current_resource.size} bytes, desired is #{new_resource.size} bytes.  Use action :regenerate to force key regeneration.")
-        elsif current_resource.type != new_resource.type
-          Chef::Log.warn("Mismatched key type!  #{current_resource.path} is #{current_resource.type}, desired is #{new_resource.type} bytes.  Use action :regenerate to force key regeneration.")
+          resource.action :delete
         end
 
-        if current_resource.format != new_resource.format
-          converge_by "change format of #{new_resource.type} private key #{new_path} from #{current_resource.format} to #{new_resource.format}" do
-            write_private_key(current_private_key)
-          end
-        elsif (@current_file_mode & 0077) != 0
-          new_mode = @current_file_mode & 07700
-          converge_by "change mode of private key #{new_path} to #{new_mode.to_s(8)}" do
-            ::File.chmod(new_mode, new_path)
-          end
-        end
-      end
-    end
-
-    if new_resource.public_key_path
-      public_key_path = new_resource.public_key_path
-      public_key_format = new_resource.public_key_format
-      Cheffish.inline_resource(self, action) do
-        public_key public_key_path do
-          source_key final_private_key
-          format public_key_format
-        end
-      end
-    end
-
-    if new_resource.after
-      new_resource.after.call(new_resource, final_private_key)
-    end
-  end
-
-  def encode_private_key(key)
-    key_format = {}
-    key_format[:format] = new_resource.format if new_resource.format
-    key_format[:pass_phrase] = new_resource.pass_phrase if new_resource.pass_phrase
-    key_format[:cipher] = new_resource.cipher if new_resource.cipher
-    Cheffish::KeyFormatter.encode(key, key_format)
-  end
-
-  def write_private_key(key)
-    ::File.open(new_path, 'w') do |file|
-      file.chmod(0600)
-      file.write(encode_private_key(key))
-    end
-  end
-
-  def new_source_key
-    @new_source_key ||= begin
-      if new_resource.source_key.is_a?(String)
-        source_key, source_key_format = Cheffish::KeyFormatter.decode(new_resource.source_key, new_resource.source_key_pass_phrase)
-        source_key
-      elsif new_resource.source_key
-        new_resource.source_key
-      elsif new_resource.source_key_path
-        source_key, source_key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.source_key_path), new_resource.source_key_pass_phrase, new_resource.source_key_path)
-        source_key
-      else
-        nil
+        @current_resource = resource
       end
     end
   end
-
-  attr_reader :current_private_key
-
-  def new_path
-    new_key_with_path[1]
-  end
-
-  def new_key_with_path
-    path = new_resource.path
-    if path.is_a?(Symbol)
-      return [ nil, path ]
-    elsif Pathname.new(path).relative?
-      private_key, private_key_path = Cheffish.get_private_key_with_path(path, run_context.config)
-      if private_key
-        return [ private_key, (private_key_path || :none) ]
-      elsif run_context.config[:private_key_write_path]
-        @should_create_directory = true
-        path = ::File.join(run_context.config[:private_key_write_path], path)
-        return [ nil, path ]
-      else
-        raise "Could not find key #{path} and Chef::Config.private_key_write_path is not set."
-      end
-    elsif ::File.exist?(path)
-      return [ IO.read(path), path ]
-    else
-      return [ nil, path ]
-    end
-  end
-
-  def load_current_resource
-    resource = Chef::Resource::PrivateKey.new(new_resource.name, run_context)
-
-    new_key, new_path = new_key_with_path
-    if new_path != :none && ::File.exist?(new_path)
-      resource.path new_path
-      @current_file_mode = ::File.stat(new_path).mode
-    else
-      resource.path :none
-    end
-
-    if new_key
-      begin
-        key, key_format = Cheffish::KeyFormatter.decode(new_key, new_resource.pass_phrase, new_path)
-        if key
-          @current_private_key = key
-          resource.format key_format[:format]
-          resource.type key_format[:type]
-          resource.size key_format[:size]
-          resource.exponent key_format[:exponent]
-          resource.pass_phrase key_format[:pass_phrase]
-          resource.cipher key_format[:cipher]
-        end
-      rescue
-        # If there's an error reading, we assume format and type are wrong and don't futz with them
-        Chef::Log.warn("Error reading #{new_path}: #{$!}")
-      end
-    else
-      resource.action :delete
-    end
-
-    @current_resource = resource
-  end
-end
-end
 end

--- a/lib/chef/provider/private_key.rb
+++ b/lib/chef/provider/private_key.rb
@@ -2,7 +2,9 @@ require 'chef/provider/lwrp_base'
 require 'openssl'
 require 'cheffish/key_formatter'
 
-class Chef::Provider::PrivateKey < Chef::Provider::LWRPBase
+class Chef
+class Provider
+class PrivateKey < Chef::Provider::LWRPBase
   provides :private_key
 
   action :create do
@@ -218,4 +220,6 @@ class Chef::Provider::PrivateKey < Chef::Provider::LWRPBase
 
     @current_resource = resource
   end
+end
+end
 end

--- a/lib/chef/provider/public_key.rb
+++ b/lib/chef/provider/public_key.rb
@@ -3,86 +3,86 @@ require 'openssl'
 require 'cheffish/key_formatter'
 
 class Chef
-class Provider
-class PublicKey < Chef::Provider::LWRPBase
-  provides :public_key
+  class Provider
+    class PublicKey < Chef::Provider::LWRPBase
+      provides :public_key
 
-  action :create do
-    if !new_source_key
-      raise "No source key specified"
-    end
-    desired_output = encode_public_key(new_source_key)
-    if Array(current_resource.action) == [ :delete ] || desired_output != IO.read(new_resource.path)
-      converge_by "write #{new_resource.format} public key #{new_resource.path} from #{new_source_key_publicity} key #{new_resource.source_key_path}" do
-        IO.write(new_resource.path, desired_output)
-        # TODO permissions on file?
-      end
-    end
-  end
-
-  action :delete do
-    if Array(current_resource.action) == [ :create ]
-      converge_by "delete public key #{new_resource.path}" do
-        ::File.unlink(new_resource.path)
-      end
-    end
-  end
-
-  def whyrun_supported?
-    true
-  end
-
-  def encode_public_key(key)
-    key_format = {}
-    key_format[:format] = new_resource.format if new_resource.format
-    Cheffish::KeyFormatter.encode(key, key_format)
-  end
-
-  attr_reader :current_public_key
-  attr_reader :new_source_key_publicity
-
-  def new_source_key
-    @new_source_key ||= begin
-      if new_resource.source_key.is_a?(String)
-        source_key, source_key_format = Cheffish::KeyFormatter.decode(new_resource.source_key, new_resource.source_key_pass_phrase)
-      elsif new_resource.source_key
-        source_key = new_resource.source_key
-      elsif new_resource.source_key_path
-        source_key, source_key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.source_key_path), new_resource.source_key_pass_phrase, new_resource.source_key_path)
-      else
-        return nil
-      end
-
-      if source_key.private?
-        @new_source_key_publicity = 'private'
-        source_key.public_key
-      else
-        @new_source_key_publicity = 'public'
-        source_key
-      end
-    end
-  end
-
-  def load_current_resource
-    if ::File.exist?(new_resource.path)
-      resource = Chef::Resource::PublicKey.new(new_resource.path, run_context)
-      begin
-        key, key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.path), nil, new_resource.path)
-        if key
-          @current_public_key = key
-          resource.format key_format[:format]
+      action :create do
+        if !new_source_key
+          raise "No source key specified"
         end
-      rescue
-        # If there is an error reading we assume format and such is broken
+        desired_output = encode_public_key(new_source_key)
+        if Array(current_resource.action) == [ :delete ] || desired_output != IO.read(new_resource.path)
+          converge_by "write #{new_resource.format} public key #{new_resource.path} from #{new_source_key_publicity} key #{new_resource.source_key_path}" do
+            IO.write(new_resource.path, desired_output)
+            # TODO permissions on file?
+          end
+        end
       end
 
-      @current_resource = resource
-    else
-      not_found_resource = Chef::Resource::PublicKey.new(new_resource.path, run_context)
-      not_found_resource.action :delete
-      @current_resource = not_found_resource
+      action :delete do
+        if Array(current_resource.action) == [ :create ]
+          converge_by "delete public key #{new_resource.path}" do
+            ::File.unlink(new_resource.path)
+          end
+        end
+      end
+
+      def whyrun_supported?
+        true
+      end
+
+      def encode_public_key(key)
+        key_format = {}
+        key_format[:format] = new_resource.format if new_resource.format
+        Cheffish::KeyFormatter.encode(key, key_format)
+      end
+
+      attr_reader :current_public_key
+      attr_reader :new_source_key_publicity
+
+      def new_source_key
+        @new_source_key ||= begin
+          if new_resource.source_key.is_a?(String)
+            source_key, source_key_format = Cheffish::KeyFormatter.decode(new_resource.source_key, new_resource.source_key_pass_phrase)
+          elsif new_resource.source_key
+            source_key = new_resource.source_key
+          elsif new_resource.source_key_path
+            source_key, source_key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.source_key_path), new_resource.source_key_pass_phrase, new_resource.source_key_path)
+          else
+            return nil
+          end
+
+          if source_key.private?
+            @new_source_key_publicity = 'private'
+            source_key.public_key
+          else
+            @new_source_key_publicity = 'public'
+            source_key
+          end
+        end
+      end
+
+      def load_current_resource
+        if ::File.exist?(new_resource.path)
+          resource = Chef::Resource::PublicKey.new(new_resource.path, run_context)
+          begin
+            key, key_format = Cheffish::KeyFormatter.decode(IO.read(new_resource.path), nil, new_resource.path)
+            if key
+              @current_public_key = key
+              resource.format key_format[:format]
+            end
+          rescue
+            # If there is an error reading we assume format and such is broken
+          end
+
+          @current_resource = resource
+        else
+          not_found_resource = Chef::Resource::PublicKey.new(new_resource.path, run_context)
+          not_found_resource.action :delete
+          @current_resource = not_found_resource
+        end
+      end
     end
   end
-end
-end
 end

--- a/lib/chef/provider/public_key.rb
+++ b/lib/chef/provider/public_key.rb
@@ -2,7 +2,9 @@ require 'chef/provider/lwrp_base'
 require 'openssl'
 require 'cheffish/key_formatter'
 
-class Chef::Provider::PublicKey < Chef::Provider::LWRPBase
+class Chef
+class Provider
+class PublicKey < Chef::Provider::LWRPBase
   provides :public_key
 
   action :create do
@@ -81,4 +83,6 @@ class Chef::Provider::PublicKey < Chef::Provider::LWRPBase
       @current_resource = not_found_resource
     end
   end
+end
+end
 end

--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -2,68 +2,68 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefAcl < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_acl'
+  class Resource
+    class ChefAcl < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_acl'
 
-  actions :create, :nothing
-  default_action :create
+      actions :create, :nothing
+      default_action :create
 
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-  end
-
-  # Path of the thing being secured, e.g. nodes, nodes/*, nodes/mynode,
-  # */*, **, roles/base, data/secrets, cookbooks/apache2, /users/*,
-  # /organizations/foo/nodes/x
-  attribute :path, :kind_of => String, :name_attribute => true
-
-  # Whether to change things recursively.  true means it will descend all children
-  # and make the same modifications to them.  :on_change will only descend if
-  # the parent has changed.  :on_change is the default.
-  attribute :recursive, :equal_to => [ true, false, :on_change ], :default => :on_change
-
-  # Specifies that this is a complete specification for the acl (i.e. rights
-  # you don't specify will be reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
-
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-
-  # rights :read, :users => 'jkeiser', :groups => [ 'admins', 'users' ]
-  # rights [ :create, :read ], :users => [ 'jkeiser', 'adam' ]
-  # rights :all, :users => 'jkeiser'
-  def rights(*values)
-    if values.size == 0
-      @rights
-    else
-      args = values.pop
-      args[:permissions] ||= []
-      values.each do |value|
-        args[:permissions] |= Array(value)
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
       end
-      @rights ||= []
-      @rights << args
+
+      # Path of the thing being secured, e.g. nodes, nodes/*, nodes/mynode,
+      # */*, **, roles/base, data/secrets, cookbooks/apache2, /users/*,
+      # /organizations/foo/nodes/x
+      attribute :path, :kind_of => String, :name_attribute => true
+
+      # Whether to change things recursively.  true means it will descend all children
+      # and make the same modifications to them.  :on_change will only descend if
+      # the parent has changed.  :on_change is the default.
+      attribute :recursive, :equal_to => [ true, false, :on_change ], :default => :on_change
+
+      # Specifies that this is a complete specification for the acl (i.e. rights
+      # you don't specify will be reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
+
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
+
+      # rights :read, :users => 'jkeiser', :groups => [ 'admins', 'users' ]
+      # rights [ :create, :read ], :users => [ 'jkeiser', 'adam' ]
+      # rights :all, :users => 'jkeiser'
+      def rights(*values)
+        if values.size == 0
+          @rights
+        else
+          args = values.pop
+          args[:permissions] ||= []
+          values.each do |value|
+            args[:permissions] |= Array(value)
+          end
+          @rights ||= []
+          @rights << args
+        end
+      end
+
+      # remove_rights :read, :users => 'jkeiser', :groups => [ 'admins', 'users' ]
+      # remove_rights [ :create, :read ], :users => [ 'jkeiser', 'adam' ]
+      # remove_rights :all, :users => [ 'jkeiser', 'adam' ]
+      def remove_rights(*values)
+        if values.size == 0
+          @remove_rights
+        else
+          args = values.pop
+          args[:permissions] ||= []
+          values.each do |value|
+            args[:permissions] |= Array(value)
+          end
+          @remove_rights ||= []
+          @remove_rights << args
+        end
+      end
     end
   end
-
-  # remove_rights :read, :users => 'jkeiser', :groups => [ 'admins', 'users' ]
-  # remove_rights [ :create, :read ], :users => [ 'jkeiser', 'adam' ]
-  # remove_rights :all, :users => [ 'jkeiser', 'adam' ]
-  def remove_rights(*values)
-    if values.size == 0
-      @remove_rights
-    else
-      args = values.pop
-      args[:permissions] ||= []
-      values.each do |value|
-        args[:permissions] |= Array(value)
-      end
-      @remove_rights ||= []
-      @remove_rights << args
-    end
-  end
-end
-end
 end

--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefAcl < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefAcl < Chef::Resource::LWRPBase
   self.resource_name = 'chef_acl'
 
   actions :create, :nothing
@@ -62,4 +64,6 @@ class Chef::Resource::ChefAcl < Chef::Resource::LWRPBase
       @remove_rights << args
     end
   end
+end
+end
 end

--- a/lib/chef/resource/chef_client.rb
+++ b/lib/chef/resource/chef_client.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefClient < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefClient < Chef::Resource::LWRPBase
   self.resource_name = 'chef_client'
 
   actions :create, :delete, :regenerate_keys, :nothing
@@ -41,4 +43,6 @@ class Chef::Resource::ChefClient < Chef::Resource::LWRPBase
   def after(&block)
     block ? @after = block : @after
   end
+end
+end
 end

--- a/lib/chef/resource/chef_client.rb
+++ b/lib/chef/resource/chef_client.rb
@@ -2,47 +2,47 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefClient < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_client'
+  class Resource
+    class ChefClient < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_client'
 
-  actions :create, :delete, :regenerate_keys, :nothing
-  default_action :create
+      actions :create, :delete, :regenerate_keys, :nothing
+      default_action :create
 
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      # Client attributes
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :admin, :kind_of => [TrueClass, FalseClass]
+      attribute :validator, :kind_of => [TrueClass, FalseClass]
+
+      # Input key
+      attribute :source_key # String or OpenSSL::PKey::*
+      attribute :source_key_path, :kind_of => String
+      attribute :source_key_pass_phrase
+
+      # Output public key (if so desired)
+      attribute :output_key_path, :kind_of => String
+      attribute :output_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
+
+      # If this is set, client is not patchy
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
+
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
+
+      # Proc that runs just before the resource executes.  Called with (resource)
+      def before(&block)
+        block ? @before = block : @before
+      end
+
+      # Proc that runs after the resource completes.  Called with (resource, json, private_key, public_key)
+      def after(&block)
+        block ? @after = block : @after
+      end
+    end
   end
-
-  # Client attributes
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :admin, :kind_of => [TrueClass, FalseClass]
-  attribute :validator, :kind_of => [TrueClass, FalseClass]
-
-  # Input key
-  attribute :source_key # String or OpenSSL::PKey::*
-  attribute :source_key_path, :kind_of => String
-  attribute :source_key_pass_phrase
-
-  # Output public key (if so desired)
-  attribute :output_key_path, :kind_of => String
-  attribute :output_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
-
-  # If this is set, client is not patchy
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
-
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-
-  # Proc that runs just before the resource executes.  Called with (resource)
-  def before(&block)
-    block ? @before = block : @before
-  end
-
-  # Proc that runs after the resource completes.  Called with (resource, json, private_key, public_key)
-  def after(&block)
-    block ? @after = block : @after
-  end
-end
-end
 end

--- a/lib/chef/resource/chef_container.rb
+++ b/lib/chef/resource/chef_container.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefContainer < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefContainer < Chef::Resource::LWRPBase
   self.resource_name = 'chef_container'
 
   actions :create, :delete, :nothing
@@ -15,4 +17,6 @@ class Chef::Resource::ChefContainer < Chef::Resource::LWRPBase
 
   attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
   attribute :chef_server, :kind_of => Hash
+end
+end
 end

--- a/lib/chef/resource/chef_container.rb
+++ b/lib/chef/resource/chef_container.rb
@@ -2,21 +2,21 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefContainer < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_container'
+  class Resource
+    class ChefContainer < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_container'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :chef_server, :kind_of => Hash
+    end
   end
-
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :chef_server, :kind_of => Hash
-end
-end
 end

--- a/lib/chef/resource/chef_data_bag.rb
+++ b/lib/chef/resource/chef_data_bag.rb
@@ -2,21 +2,21 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefDataBag < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_data_bag'
+  class Resource
+    class ChefDataBag < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_data_bag'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+
+      attribute :chef_server, :kind_of => Hash
+    end
   end
-
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-
-  attribute :chef_server, :kind_of => Hash
-end
-end
 end

--- a/lib/chef/resource/chef_data_bag.rb
+++ b/lib/chef/resource/chef_data_bag.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefDataBag < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefDataBag < Chef::Resource::LWRPBase
   self.resource_name = 'chef_data_bag'
 
   actions :create, :delete, :nothing
@@ -15,4 +17,6 @@ class Chef::Resource::ChefDataBag < Chef::Resource::LWRPBase
   attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
 
   attribute :chef_server, :kind_of => Hash
+end
+end
 end

--- a/lib/chef/resource/chef_data_bag_item.rb
+++ b/lib/chef/resource/chef_data_bag_item.rb
@@ -44,6 +44,8 @@ class ChefDataBagItem < Chef::Resource::LWRPBase
     result
   end
 
+  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+  # don't redefine it if it's already there
   NOT_PASSED = Object.new unless defined?(NOT_PASSED)
 
   def id(value = NOT_PASSED)

--- a/lib/chef/resource/chef_data_bag_item.rb
+++ b/lib/chef/resource/chef_data_bag_item.rb
@@ -3,119 +3,119 @@ require 'chef/config'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefDataBagItem < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_data_bag_item'
+  class Resource
+    class ChefDataBagItem < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_data_bag_item'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  def initialize(*args)
-    super
-    name @name
-    if !data_bag
-      data_bag run_context.cheffish.current_data_bag
-    end
-    if run_context.cheffish.current_data_bag_item_encryption
-      @encrypt = true if run_context.cheffish.current_data_bag_item_encryption[:encrypt_all]
-      @secret = run_context.cheffish.current_data_bag_item_encryption[:secret]
-      @secret_path = run_context.cheffish.current_data_bag_item_encryption[:secret_path] || run_context.config[:encrypted_data_bag_secret]
-      @encryption_cipher = run_context.cheffish.current_data_bag_item_encryption[:encryption_cipher]
-      @encryption_version = run_context.cheffish.current_data_bag_item_encryption[:encryption_version] || run_context.config[:data_bag_encrypt_version]
-      @old_secret = run_context.cheffish.current_data_bag_item_encryption[:old_secret]
-      @old_secret_path = run_context.cheffish.current_data_bag_item_encryption[:old_secret_path]
-    end
-    chef_server run_context.cheffish.current_chef_server
-  end
+      def initialize(*args)
+        super
+        name @name
+        if !data_bag
+          data_bag run_context.cheffish.current_data_bag
+        end
+        if run_context.cheffish.current_data_bag_item_encryption
+          @encrypt = true if run_context.cheffish.current_data_bag_item_encryption[:encrypt_all]
+          @secret = run_context.cheffish.current_data_bag_item_encryption[:secret]
+          @secret_path = run_context.cheffish.current_data_bag_item_encryption[:secret_path] || run_context.config[:encrypted_data_bag_secret]
+          @encryption_cipher = run_context.cheffish.current_data_bag_item_encryption[:encryption_cipher]
+          @encryption_version = run_context.cheffish.current_data_bag_item_encryption[:encryption_version] || run_context.config[:data_bag_encrypt_version]
+          @old_secret = run_context.cheffish.current_data_bag_item_encryption[:old_secret]
+          @old_secret_path = run_context.cheffish.current_data_bag_item_encryption[:old_secret_path]
+        end
+        chef_server run_context.cheffish.current_chef_server
+      end
 
-  def name(*args)
-    result = super(*args)
-    if args.size == 1
-      parts = name.split('/')
-      if parts.size == 1
-        @id = parts[0]
-      elsif parts.size == 2
-        @data_bag = parts[0]
-        @id = parts[1]
-      else
-        raise "Name #{args[0].inspect} must be a string with 1 or 2 parts, either 'id' or 'data_bag/id"
+      def name(*args)
+        result = super(*args)
+        if args.size == 1
+          parts = name.split('/')
+          if parts.size == 1
+            @id = parts[0]
+          elsif parts.size == 2
+            @data_bag = parts[0]
+            @id = parts[1]
+          else
+            raise "Name #{args[0].inspect} must be a string with 1 or 2 parts, either 'id' or 'data_bag/id"
+          end
+        end
+        result
+      end
+
+      # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+      # don't redefine it if it's already there
+      NOT_PASSED = Object.new unless defined?(NOT_PASSED)
+
+      def id(value = NOT_PASSED)
+        if value == NOT_PASSED
+          @id
+        else
+          @id = value
+          name data_bag ? "#{data_bag}/#{id}" : id
+        end
+      end
+      def data_bag(value = NOT_PASSED)
+        if value == NOT_PASSED
+          @data_bag
+        else
+          @data_bag = value
+          name data_bag ? "#{data_bag}/#{id}" : id
+        end
+      end
+      attribute :raw_data, :kind_of => Hash
+
+      # If secret or secret_path are set, encrypt is assumed true.  encrypt exists mainly for with_secret and with_secret_path
+      attribute :encrypt, :kind_of => [TrueClass, FalseClass]
+      #attribute :secret, :kind_of => String
+      def secret(new_secret = nil)
+        if !new_secret
+          @secret
+        else
+          @secret = new_secret
+          @encrypt = true if @encrypt.nil?
+        end
+      end
+      #attribute :secret_path, :kind_of => String
+      def secret_path(new_secret_path = nil)
+        if !new_secret_path
+          @secret_path
+        else
+          @secret_path = new_secret_path
+          @encrypt = true if @encrypt.nil?
+        end
+      end
+      attribute :encryption_version, :kind_of => Integer
+
+      # Old secret (or secrets) to read the old data bag when we are changing keys and re-encrypting data
+      attribute :old_secret, :kind_of => [String, Array]
+      attribute :old_secret_path, :kind_of => [String, Array]
+
+      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+      # reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
+
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
+
+      # value 'ip_address', '127.0.0.1'
+      # value [ 'pushy', 'port' ], '9000'
+      # value 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # value 'ip_address', :delete
+      attr_reader :raw_data_modifiers
+      def value(raw_data_path, value=NOT_PASSED, &block)
+        @raw_data_modifiers ||= []
+        if value != NOT_PASSED
+          @raw_data_modifiers << [ raw_data_path, value ]
+        elsif block
+          @raw_data_modifiers << [ raw_data_path, block ]
+        else
+          raise "value requires either a value or a block"
+        end
       end
     end
-    result
   end
-
-  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
-  # don't redefine it if it's already there
-  NOT_PASSED = Object.new unless defined?(NOT_PASSED)
-
-  def id(value = NOT_PASSED)
-    if value == NOT_PASSED
-      @id
-    else
-      @id = value
-      name data_bag ? "#{data_bag}/#{id}" : id
-    end
-  end
-  def data_bag(value = NOT_PASSED)
-    if value == NOT_PASSED
-      @data_bag
-    else
-      @data_bag = value
-      name data_bag ? "#{data_bag}/#{id}" : id
-    end
-  end
-  attribute :raw_data, :kind_of => Hash
-
-  # If secret or secret_path are set, encrypt is assumed true.  encrypt exists mainly for with_secret and with_secret_path
-  attribute :encrypt, :kind_of => [TrueClass, FalseClass]
-  #attribute :secret, :kind_of => String
-  def secret(new_secret = nil)
-    if !new_secret
-      @secret
-    else
-      @secret = new_secret
-      @encrypt = true if @encrypt.nil?
-    end
-  end
-  #attribute :secret_path, :kind_of => String
-  def secret_path(new_secret_path = nil)
-    if !new_secret_path
-      @secret_path
-    else
-      @secret_path = new_secret_path
-      @encrypt = true if @encrypt.nil?
-    end
-  end
-  attribute :encryption_version, :kind_of => Integer
-
-  # Old secret (or secrets) to read the old data bag when we are changing keys and re-encrypting data
-  attribute :old_secret, :kind_of => [String, Array]
-  attribute :old_secret_path, :kind_of => [String, Array]
-
-  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-  # reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
-
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-
-  # value 'ip_address', '127.0.0.1'
-  # value [ 'pushy', 'port' ], '9000'
-  # value 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # value 'ip_address', :delete
-  attr_reader :raw_data_modifiers
-  def value(raw_data_path, value=NOT_PASSED, &block)
-    @raw_data_modifiers ||= []
-    if value != NOT_PASSED
-      @raw_data_modifiers << [ raw_data_path, value ]
-    elsif block
-      @raw_data_modifiers << [ raw_data_path, block ]
-    else
-      raise "value requires either a value or a block"
-    end
-  end
-end
-end
 end

--- a/lib/chef/resource/chef_data_bag_item.rb
+++ b/lib/chef/resource/chef_data_bag_item.rb
@@ -2,7 +2,9 @@ require 'cheffish'
 require 'chef/config'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefDataBagItem < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefDataBagItem < Chef::Resource::LWRPBase
   self.resource_name = 'chef_data_bag_item'
 
   actions :create, :delete, :nothing
@@ -42,7 +44,8 @@ class Chef::Resource::ChefDataBagItem < Chef::Resource::LWRPBase
     result
   end
 
-  NOT_PASSED = Object.new
+  NOT_PASSED = Object.new unless defined?(NOT_PASSED)
+
   def id(value = NOT_PASSED)
     if value == NOT_PASSED
       @id
@@ -111,4 +114,6 @@ class Chef::Resource::ChefDataBagItem < Chef::Resource::LWRPBase
       raise "value requires either a value or a block"
     end
   end
+end
+end
 end

--- a/lib/chef/resource/chef_environment.rb
+++ b/lib/chef/resource/chef_environment.rb
@@ -30,6 +30,8 @@ class ChefEnvironment < Chef::Resource::LWRPBase
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
 
+  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+  # don't redefine it if it's already there
   NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   # default 'ip_address', '127.0.0.1'

--- a/lib/chef/resource/chef_environment.rb
+++ b/lib/chef/resource/chef_environment.rb
@@ -2,7 +2,9 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 require 'chef/environment'
 
-class Chef::Resource::ChefEnvironment < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefEnvironment < Chef::Resource::LWRPBase
   self.resource_name = 'chef_environment'
 
   actions :create, :delete, :nothing
@@ -28,7 +30,7 @@ class Chef::Resource::ChefEnvironment < Chef::Resource::LWRPBase
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
 
-  NOT_PASSED=Object.new
+  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   # default 'ip_address', '127.0.0.1'
   # default [ 'pushy', 'port' ], '9000'
@@ -68,4 +70,6 @@ class Chef::Resource::ChefEnvironment < Chef::Resource::LWRPBase
 
   alias :attributes :default_attributes
   alias :attribute :default
+end
+end
 end

--- a/lib/chef/resource/chef_environment.rb
+++ b/lib/chef/resource/chef_environment.rb
@@ -3,75 +3,75 @@ require 'chef/resource/lwrp_base'
 require 'chef/environment'
 
 class Chef
-class Resource
-class ChefEnvironment < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_environment'
+  class Resource
+    class ChefEnvironment < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_environment'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-  end
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
 
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :description, :kind_of => String
-  attribute :cookbook_versions, :kind_of => Hash, :callbacks => {
-    "should have valid cookbook versions" => lambda { |value| Chef::Environment.validate_cookbook_versions(value) }
-  }
-  attribute :default_attributes, :kind_of => Hash
-  attribute :override_attributes, :kind_of => Hash
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :description, :kind_of => String
+      attribute :cookbook_versions, :kind_of => Hash, :callbacks => {
+        "should have valid cookbook versions" => lambda { |value| Chef::Environment.validate_cookbook_versions(value) }
+      }
+      attribute :default_attributes, :kind_of => Hash
+      attribute :override_attributes, :kind_of => Hash
 
-  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-  # reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
+      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+      # reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
 
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
 
-  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
-  # don't redefine it if it's already there
-  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
+      # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+      # don't redefine it if it's already there
+      NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
-  # default 'ip_address', '127.0.0.1'
-  # default [ 'pushy', 'port' ], '9000'
-  # default 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # default 'ip_address', :delete
-  attr_reader :default_attribute_modifiers
-  def default(attribute_path, value=NOT_PASSED, &block)
-    @default_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @default_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @default_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "default requires either a value or a block"
+      # default 'ip_address', '127.0.0.1'
+      # default [ 'pushy', 'port' ], '9000'
+      # default 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # default 'ip_address', :delete
+      attr_reader :default_attribute_modifiers
+      def default(attribute_path, value=NOT_PASSED, &block)
+        @default_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @default_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @default_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "default requires either a value or a block"
+        end
+      end
+
+      # override 'ip_address', '127.0.0.1'
+      # override [ 'pushy', 'port' ], '9000'
+      # override 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # override 'ip_address', :delete
+      attr_reader :override_attribute_modifiers
+      def override(attribute_path, value=NOT_PASSED, &block)
+        @override_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @override_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @override_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "override requires either a value or a block"
+        end
+      end
+
+      alias :attributes :default_attributes
+      alias :attribute :default
     end
   end
-
-  # override 'ip_address', '127.0.0.1'
-  # override [ 'pushy', 'port' ], '9000'
-  # override 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # override 'ip_address', :delete
-  attr_reader :override_attribute_modifiers
-  def override(attribute_path, value=NOT_PASSED, &block)
-    @override_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @override_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @override_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "override requires either a value or a block"
-    end
-  end
-
-  alias :attributes :default_attributes
-  alias :attribute :default
-end
-end
 end

--- a/lib/chef/resource/chef_group.rb
+++ b/lib/chef/resource/chef_group.rb
@@ -2,7 +2,9 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
-class Chef::Resource::ChefGroup < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefGroup < Chef::Resource::LWRPBase
   self.resource_name = 'chef_group'
 
   actions :create, :delete, :nothing
@@ -46,4 +48,6 @@ class Chef::Resource::ChefGroup < Chef::Resource::LWRPBase
 
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
+end
+end
 end

--- a/lib/chef/resource/chef_group.rb
+++ b/lib/chef/resource/chef_group.rb
@@ -3,51 +3,51 @@ require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
 class Chef
-class Resource
-class ChefGroup < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_group'
+  class Resource
+    class ChefGroup < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_group'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-    @users = []
-    @clients = []
-    @groups = []
-    @remove_users = []
-    @remove_clients = []
-    @remove_groups = []
-  end
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+        @users = []
+        @clients = []
+        @groups = []
+        @remove_users = []
+        @remove_clients = []
+        @remove_groups = []
+      end
 
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  def users(*users)
-    users.size == 0 ? @users : (@users |= users.flatten)
-  end
-  def clients(*clients)
-    clients.size == 0 ? @clients : (@clients |= clients.flatten)
-  end
-  def groups(*groups)
-    groups.size == 0 ? @groups : (@groups |= groups.flatten)
-  end
-  def remove_users(*remove_users)
-    remove_users.size == 0 ? @remove_users : (@remove_users |= remove_users.flatten)
-  end
-  def remove_clients(*remove_clients)
-    remove_clients.size == 0 ? @remove_clients : (@remove_clients |= remove_clients.flatten)
-  end
-  def remove_groups(*remove_groups)
-    remove_groups.size == 0 ? @remove_groups : (@remove_groups |= remove_groups.flatten)
-  end
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      def users(*users)
+        users.size == 0 ? @users : (@users |= users.flatten)
+      end
+      def clients(*clients)
+        clients.size == 0 ? @clients : (@clients |= clients.flatten)
+      end
+      def groups(*groups)
+        groups.size == 0 ? @groups : (@groups |= groups.flatten)
+      end
+      def remove_users(*remove_users)
+        remove_users.size == 0 ? @remove_users : (@remove_users |= remove_users.flatten)
+      end
+      def remove_clients(*remove_clients)
+        remove_clients.size == 0 ? @remove_clients : (@remove_clients |= remove_clients.flatten)
+      end
+      def remove_groups(*remove_groups)
+        remove_groups.size == 0 ? @remove_groups : (@remove_groups |= remove_groups.flatten)
+      end
 
-  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-  # reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
+      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+      # reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
 
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-end
-end
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
+    end
+  end
 end

--- a/lib/chef/resource/chef_mirror.rb
+++ b/lib/chef/resource/chef_mirror.rb
@@ -2,51 +2,51 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefMirror < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_mirror'
+  class Resource
+    class ChefMirror < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_mirror'
 
-  actions :upload, :download, :nothing
-  default_action :nothing
+      actions :upload, :download, :nothing
+      default_action :nothing
 
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      # Path of the data to mirror, e.g. nodes, nodes/*, nodes/mynode,
+      # */*, **, roles/base, data/secrets, cookbooks/apache2, etc.
+      attribute :path, :kind_of => String, :name_attribute => true
+
+      # Local path.  Can be a string (top level of repository) or hash
+      # (:chef_repo_path, :node_path, etc.)
+      # If neither chef_repo_path nor versioned_cookbooks are set, they default to their
+      # Chef::Config values.  If chef_repo_path is set but versioned_cookbooks is not,
+      # versioned_cookbooks defaults to true.
+      attribute :chef_repo_path, :kind_of => [ String, Hash ]
+
+      # Whether the repo path should contain cookbooks with versioned names,
+      # i.e. cookbooks/mysql-1.0.0, cookbooks/mysql-1.2.0, etc.
+      # Defaults to true if chef_repo_path is specified, or to Chef::Config.versioned_cookbooks otherwise.
+      attribute :versioned_cookbooks, :kind_of => [ TrueClass, FalseClass ]
+
+      # Chef server
+      attribute :chef_server, :kind_of => Hash
+
+      # Whether to purge deleted things: if we do not have cookbooks/x locally and we
+      # *do* have cookbooks/x remotely, then :upload with purge will delete it.
+      # Defaults to false.
+      attribute :purge, :kind_of => [ TrueClass, FalseClass ]
+
+      # Whether to freeze cookbooks on upload
+      attribute :freeze, :kind_of => [ TrueClass, FalseClass ]
+
+      # If this is true, only new files will be copied.  File contents will not be
+      # diffed, so changed files will never be uploaded.
+      attribute :no_diff, :kind_of => [ TrueClass, FalseClass ]
+
+      # Number of parallel threads to list/upload/download with.  Defaults to 10.
+      attribute :concurrency, :kind_of => Integer
+    end
   end
-
-  # Path of the data to mirror, e.g. nodes, nodes/*, nodes/mynode,
-  # */*, **, roles/base, data/secrets, cookbooks/apache2, etc.
-  attribute :path, :kind_of => String, :name_attribute => true
-
-  # Local path.  Can be a string (top level of repository) or hash
-  # (:chef_repo_path, :node_path, etc.)
-  # If neither chef_repo_path nor versioned_cookbooks are set, they default to their
-  # Chef::Config values.  If chef_repo_path is set but versioned_cookbooks is not,
-  # versioned_cookbooks defaults to true.
-  attribute :chef_repo_path, :kind_of => [ String, Hash ]
-
-  # Whether the repo path should contain cookbooks with versioned names,
-  # i.e. cookbooks/mysql-1.0.0, cookbooks/mysql-1.2.0, etc.
-  # Defaults to true if chef_repo_path is specified, or to Chef::Config.versioned_cookbooks otherwise.
-  attribute :versioned_cookbooks, :kind_of => [ TrueClass, FalseClass ]
-
-  # Chef server
-  attribute :chef_server, :kind_of => Hash
-
-  # Whether to purge deleted things: if we do not have cookbooks/x locally and we
-  # *do* have cookbooks/x remotely, then :upload with purge will delete it.
-  # Defaults to false.
-  attribute :purge, :kind_of => [ TrueClass, FalseClass ]
-
-  # Whether to freeze cookbooks on upload
-  attribute :freeze, :kind_of => [ TrueClass, FalseClass ]
-
-  # If this is true, only new files will be copied.  File contents will not be
-  # diffed, so changed files will never be uploaded.
-  attribute :no_diff, :kind_of => [ TrueClass, FalseClass ]
-
-  # Number of parallel threads to list/upload/download with.  Defaults to 10.
-  attribute :concurrency, :kind_of => Integer
-end
-end
 end

--- a/lib/chef/resource/chef_mirror.rb
+++ b/lib/chef/resource/chef_mirror.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefMirror < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefMirror < Chef::Resource::LWRPBase
   self.resource_name = 'chef_mirror'
 
   actions :upload, :download, :nothing
@@ -45,4 +47,6 @@ class Chef::Resource::ChefMirror < Chef::Resource::LWRPBase
 
   # Number of parallel threads to list/upload/download with.  Defaults to 10.
   attribute :concurrency, :kind_of => Integer
+end
+end
 end

--- a/lib/chef/resource/chef_node.rb
+++ b/lib/chef/resource/chef_node.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefNode < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefNode < Chef::Resource::LWRPBase
   self.resource_name = 'chef_node'
 
   actions :create, :delete, :nothing
@@ -15,4 +17,6 @@ class Chef::Resource::ChefNode < Chef::Resource::LWRPBase
   end
 
   Cheffish.node_attributes(self)
+end
+end
 end

--- a/lib/chef/resource/chef_node.rb
+++ b/lib/chef/resource/chef_node.rb
@@ -2,21 +2,21 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefNode < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_node'
+  class Resource
+    class ChefNode < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_node'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_environment run_context.cheffish.current_environment
-    chef_server run_context.cheffish.current_chef_server
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_environment run_context.cheffish.current_environment
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      Cheffish.node_attributes(self)
+    end
   end
-
-  Cheffish.node_attributes(self)
-end
-end
 end

--- a/lib/chef/resource/chef_organization.rb
+++ b/lib/chef/resource/chef_organization.rb
@@ -3,67 +3,67 @@ require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
 class Chef
-class Resource
-class ChefOrganization < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_organization'
+  class Resource
+    class ChefOrganization < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_organization'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-    @invites = nil
-    @members = nil
-    @remove_members = []
-  end
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+        @invites = nil
+        @members = nil
+        @remove_members = []
+      end
 
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :full_name, :kind_of => String
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :full_name, :kind_of => String
 
-  # A list of users who must at least be invited to the org (but may already be
-  # members).  Invites will be sent to users who are not already invited/in the org.
-  def invites(*users)
-    if users.size == 0
-      @invites || []
-    else
-      @invites ||= []
-      @invites |= users.flatten
+      # A list of users who must at least be invited to the org (but may already be
+      # members).  Invites will be sent to users who are not already invited/in the org.
+      def invites(*users)
+        if users.size == 0
+          @invites || []
+        else
+          @invites ||= []
+          @invites |= users.flatten
+        end
+      end
+
+      def invites_specified?
+        !!@invites
+      end
+
+      # A list of users who must be members of the org.  This will use the
+      # new Chef 12 POST /organizations/ORG/users endpoint to add them
+      # directly to the org.  If you do not have permission to perform
+      # this operation, and the users are not a part of the org, the
+      # resource update will fail.
+      def members(*users)
+        if users.size == 0
+          @members || []
+        else
+          @members ||= []
+          @members |= users.flatten
+        end
+      end
+
+      def members_specified?
+        !!@members
+      end
+
+      # A list of users who must not be members of the org.  These users will be removed
+      # from the org and invites will be revoked (if any).
+      def remove_members(*users)
+        users.size == 0 ? @remove_members : (@remove_members |= users.flatten)
+      end
+
+      attribute :complete, :kind_of => [ TrueClass, FalseClass ]
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
     end
   end
-
-  def invites_specified?
-    !!@invites
-  end
-
-  # A list of users who must be members of the org.  This will use the
-  # new Chef 12 POST /organizations/ORG/users endpoint to add them
-  # directly to the org.  If you do not have permission to perform
-  # this operation, and the users are not a part of the org, the
-  # resource update will fail.
-  def members(*users)
-    if users.size == 0
-      @members || []
-    else
-      @members ||= []
-      @members |= users.flatten
-    end
-  end
-
-  def members_specified?
-    !!@members
-  end
-
-  # A list of users who must not be members of the org.  These users will be removed
-  # from the org and invites will be revoked (if any).
-  def remove_members(*users)
-    users.size == 0 ? @remove_members : (@remove_members |= users.flatten)
-  end
-
-  attribute :complete, :kind_of => [ TrueClass, FalseClass ]
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-end
-end
 end

--- a/lib/chef/resource/chef_organization.rb
+++ b/lib/chef/resource/chef_organization.rb
@@ -2,7 +2,9 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
-class Chef::Resource::ChefOrganization < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefOrganization < Chef::Resource::LWRPBase
   self.resource_name = 'chef_organization'
 
   actions :create, :delete, :nothing
@@ -62,4 +64,6 @@ class Chef::Resource::ChefOrganization < Chef::Resource::LWRPBase
   attribute :complete, :kind_of => [ TrueClass, FalseClass ]
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
+end
+end
 end

--- a/lib/chef/resource/chef_resolved_cookbooks.rb
+++ b/lib/chef/resource/chef_resolved_cookbooks.rb
@@ -1,35 +1,35 @@
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefResolvedCookbooks < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_resolved_cookbooks'
+  class Resource
+    class ChefResolvedCookbooks < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_resolved_cookbooks'
 
-  actions :resolve, :nothing
-  default_action :resolve
+      actions :resolve, :nothing
+      default_action :resolve
 
-  def initialize(*args)
-    super
-    require 'berkshelf'
-    berksfile Berkshelf::Berksfile.new('/tmp/Berksfile')
-    chef_server run_context.cheffish.current_chef_server
-    @cookbooks_from = []
-  end
+      def initialize(*args)
+        super
+        require 'berkshelf'
+        berksfile Berkshelf::Berksfile.new('/tmp/Berksfile')
+        chef_server run_context.cheffish.current_chef_server
+        @cookbooks_from = []
+      end
 
-  extend Forwardable
+      extend Forwardable
 
-  def_delegators :@berksfile, :cookbook, :extension, :group, :metadata, :source
+      def_delegators :@berksfile, :cookbook, :extension, :group, :metadata, :source
 
-  def cookbooks_from(path = nil)
-    if path
-      @cookbooks_from << path
-    else
-      @cookbooks_from
+      def cookbooks_from(path = nil)
+        if path
+          @cookbooks_from << path
+        else
+          @cookbooks_from
+        end
+      end
+
+      attribute :berksfile
+      attribute :chef_server
     end
   end
-
-  attribute :berksfile
-  attribute :chef_server
-end
-end
 end

--- a/lib/chef/resource/chef_resolved_cookbooks.rb
+++ b/lib/chef/resource/chef_resolved_cookbooks.rb
@@ -1,6 +1,8 @@
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefResolvedCookbooks < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefResolvedCookbooks < Chef::Resource::LWRPBase
   self.resource_name = 'chef_resolved_cookbooks'
 
   actions :resolve, :nothing
@@ -28,4 +30,6 @@ class Chef::Resource::ChefResolvedCookbooks < Chef::Resource::LWRPBase
 
   attribute :berksfile
   attribute :chef_server
+end
+end
 end

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -27,8 +27,8 @@ class Chef::Resource::ChefRole < Chef::Resource::LWRPBase
 
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
-
-  NOT_PASSED=Object.new
+  
+  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   # default_attribute 'ip_address', '127.0.0.1'
   # default_attribute [ 'pushy', 'port' ], '9000'

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -3,106 +3,106 @@ require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
 class Chef
-  class Resource
-    class ChefRole < Chef::Resource::LWRPBase
-      self.resource_name = 'chef_role'
+class Resource
+class ChefRole < Chef::Resource::LWRPBase
+  self.resource_name = 'chef_role'
 
-      actions :create, :delete, :nothing
-      default_action :create
+  actions :create, :delete, :nothing
+  default_action :create
 
-      # Grab environment from with_environment
-      def initialize(*args)
-        super
-        chef_server run_context.cheffish.current_chef_server
-      end
+  # Grab environment from with_environment
+  def initialize(*args)
+    super
+    chef_server run_context.cheffish.current_chef_server
+  end
 
-      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-      attribute :description, :kind_of => String
-      attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
-      attribute :env_run_lists, :kind_of => Hash
-      attribute :default_attributes, :kind_of => Hash
-      attribute :override_attributes, :kind_of => Hash
+  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+  attribute :description, :kind_of => String
+  attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
+  attribute :env_run_lists, :kind_of => Hash
+  attribute :default_attributes, :kind_of => Hash
+  attribute :override_attributes, :kind_of => Hash
 
-      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-      # reset to their defaults)
-      attribute :complete, :kind_of => [TrueClass, FalseClass]
+  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+  # reset to their defaults)
+  attribute :complete, :kind_of => [TrueClass, FalseClass]
 
-      attribute :raw_json, :kind_of => Hash
-      attribute :chef_server, :kind_of => Hash
+  attribute :raw_json, :kind_of => Hash
+  attribute :chef_server, :kind_of => Hash
 
-      NOT_PASSED=Object.new unless defined?(NOT_PASSED)
+  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
-      # default_attribute 'ip_address', '127.0.0.1'
-      # default_attribute [ 'pushy', 'port' ], '9000'
-      # default_attribute 'ip_addresses' do |existing_value|
-      #   (existing_value || []) + [ '127.0.0.1' ]
-      # end
-      # default_attribute 'ip_address', :delete
-      attr_reader :default_attribute_modifiers
-      def default_attribute(attribute_path, value=NOT_PASSED, &block)
-        @default_attribute_modifiers ||= []
-        if value != NOT_PASSED
-          @default_attribute_modifiers << [ attribute_path, value ]
-        elsif block
-          @default_attribute_modifiers << [ attribute_path, block ]
-        else
-          raise "default_attribute requires either a value or a block"
-        end
-      end
-
-      # override_attribute 'ip_address', '127.0.0.1'
-      # override_attribute [ 'pushy', 'port' ], '9000'
-      # override_attribute 'ip_addresses' do |existing_value|
-      #   (existing_value || []) + [ '127.0.0.1' ]
-      # end
-      # override_attribute 'ip_address', :delete
-      attr_reader :override_attribute_modifiers
-      def override_attribute(attribute_path, value=NOT_PASSED, &block)
-        @override_attribute_modifiers ||= []
-        if value != NOT_PASSED
-          @override_attribute_modifiers << [ attribute_path, value ]
-        elsif block
-          @override_attribute_modifiers << [ attribute_path, block ]
-        else
-          raise "override_attribute requires either a value or a block"
-        end
-      end
-
-      # Order matters--if two things here are in the wrong order, they will be flipped in the run list
-      # recipe 'apache', 'mysql'
-      # recipe 'recipe@version'
-      # recipe 'recipe'
-      # role ''
-      attr_reader :run_list_modifiers
-      attr_reader :run_list_removers
-      def recipe(*recipes)
-        if recipes.size == 0
-          raise ArgumentError, "At least one recipe must be specified"
-        end
-        @run_list_modifiers ||= []
-        @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-      end
-      def role(*roles)
-        if roles.size == 0
-          raise ArgumentError, "At least one role must be specified"
-        end
-        @run_list_modifiers ||= []
-        @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
-      end
-      def remove_recipe(*recipes)
-        if recipes.size == 0
-          raise ArgumentError, "At least one recipe must be specified"
-        end
-        @run_list_removers ||= []
-        @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-      end
-      def remove_role(*roles)
-        if roles.size == 0
-          raise ArgumentError, "At least one role must be specified"
-        end
-        @run_list_removers ||= []
-        @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
-      end
+  # default_attribute 'ip_address', '127.0.0.1'
+  # default_attribute [ 'pushy', 'port' ], '9000'
+  # default_attribute 'ip_addresses' do |existing_value|
+  #   (existing_value || []) + [ '127.0.0.1' ]
+  # end
+  # default_attribute 'ip_address', :delete
+  attr_reader :default_attribute_modifiers
+  def default_attribute(attribute_path, value=NOT_PASSED, &block)
+    @default_attribute_modifiers ||= []
+    if value != NOT_PASSED
+      @default_attribute_modifiers << [ attribute_path, value ]
+    elsif block
+      @default_attribute_modifiers << [ attribute_path, block ]
+    else
+      raise "default_attribute requires either a value or a block"
     end
   end
+
+  # override_attribute 'ip_address', '127.0.0.1'
+  # override_attribute [ 'pushy', 'port' ], '9000'
+  # override_attribute 'ip_addresses' do |existing_value|
+  #   (existing_value || []) + [ '127.0.0.1' ]
+  # end
+  # override_attribute 'ip_address', :delete
+  attr_reader :override_attribute_modifiers
+  def override_attribute(attribute_path, value=NOT_PASSED, &block)
+    @override_attribute_modifiers ||= []
+    if value != NOT_PASSED
+      @override_attribute_modifiers << [ attribute_path, value ]
+    elsif block
+      @override_attribute_modifiers << [ attribute_path, block ]
+    else
+      raise "override_attribute requires either a value or a block"
+    end
+  end
+
+  # Order matters--if two things here are in the wrong order, they will be flipped in the run list
+  # recipe 'apache', 'mysql'
+  # recipe 'recipe@version'
+  # recipe 'recipe'
+  # role ''
+  attr_reader :run_list_modifiers
+  attr_reader :run_list_removers
+  def recipe(*recipes)
+    if recipes.size == 0
+      raise ArgumentError, "At least one recipe must be specified"
+    end
+    @run_list_modifiers ||= []
+    @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+  end
+  def role(*roles)
+    if roles.size == 0
+      raise ArgumentError, "At least one role must be specified"
+    end
+    @run_list_modifiers ||= []
+    @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
+  end
+  def remove_recipe(*recipes)
+    if recipes.size == 0
+      raise ArgumentError, "At least one recipe must be specified"
+    end
+    @run_list_removers ||= []
+    @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+  end
+  def remove_role(*roles)
+    if roles.size == 0
+      raise ArgumentError, "At least one role must be specified"
+    end
+    @run_list_removers ||= []
+    @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
+  end
+end
+end
 end

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -30,6 +30,8 @@ class ChefRole < Chef::Resource::LWRPBase
   attribute :raw_json, :kind_of => Hash
   attribute :chef_server, :kind_of => Hash
 
+  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+  # don't redefine it if it's already there
   NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   # default_attribute 'ip_address', '127.0.0.1'

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -3,108 +3,108 @@ require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
 class Chef
-class Resource
-class ChefRole < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_role'
+  class Resource
+    class ChefRole < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_role'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-  end
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
 
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :description, :kind_of => String
-  attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
-  attribute :env_run_lists, :kind_of => Hash
-  attribute :default_attributes, :kind_of => Hash
-  attribute :override_attributes, :kind_of => Hash
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :description, :kind_of => String
+      attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
+      attribute :env_run_lists, :kind_of => Hash
+      attribute :default_attributes, :kind_of => Hash
+      attribute :override_attributes, :kind_of => Hash
 
-  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-  # reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
+      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+      # reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
 
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
 
-  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
-  # don't redefine it if it's already there
-  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
+      # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+      # don't redefine it if it's already there
+      NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
-  # default_attribute 'ip_address', '127.0.0.1'
-  # default_attribute [ 'pushy', 'port' ], '9000'
-  # default_attribute 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # default_attribute 'ip_address', :delete
-  attr_reader :default_attribute_modifiers
-  def default_attribute(attribute_path, value=NOT_PASSED, &block)
-    @default_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @default_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @default_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "default_attribute requires either a value or a block"
+      # default_attribute 'ip_address', '127.0.0.1'
+      # default_attribute [ 'pushy', 'port' ], '9000'
+      # default_attribute 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # default_attribute 'ip_address', :delete
+      attr_reader :default_attribute_modifiers
+      def default_attribute(attribute_path, value=NOT_PASSED, &block)
+        @default_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @default_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @default_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "default_attribute requires either a value or a block"
+        end
+      end
+
+      # override_attribute 'ip_address', '127.0.0.1'
+      # override_attribute [ 'pushy', 'port' ], '9000'
+      # override_attribute 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # override_attribute 'ip_address', :delete
+      attr_reader :override_attribute_modifiers
+      def override_attribute(attribute_path, value=NOT_PASSED, &block)
+        @override_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @override_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @override_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "override_attribute requires either a value or a block"
+        end
+      end
+
+      # Order matters--if two things here are in the wrong order, they will be flipped in the run list
+      # recipe 'apache', 'mysql'
+      # recipe 'recipe@version'
+      # recipe 'recipe'
+      # role ''
+      attr_reader :run_list_modifiers
+      attr_reader :run_list_removers
+      def recipe(*recipes)
+        if recipes.size == 0
+          raise ArgumentError, "At least one recipe must be specified"
+        end
+        @run_list_modifiers ||= []
+        @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+      end
+      def role(*roles)
+        if roles.size == 0
+          raise ArgumentError, "At least one role must be specified"
+        end
+        @run_list_modifiers ||= []
+        @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
+      end
+      def remove_recipe(*recipes)
+        if recipes.size == 0
+          raise ArgumentError, "At least one recipe must be specified"
+        end
+        @run_list_removers ||= []
+        @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+      end
+      def remove_role(*roles)
+        if roles.size == 0
+          raise ArgumentError, "At least one role must be specified"
+        end
+        @run_list_removers ||= []
+        @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
+      end
     end
   end
-
-  # override_attribute 'ip_address', '127.0.0.1'
-  # override_attribute [ 'pushy', 'port' ], '9000'
-  # override_attribute 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # override_attribute 'ip_address', :delete
-  attr_reader :override_attribute_modifiers
-  def override_attribute(attribute_path, value=NOT_PASSED, &block)
-    @override_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @override_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @override_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "override_attribute requires either a value or a block"
-    end
-  end
-
-  # Order matters--if two things here are in the wrong order, they will be flipped in the run list
-  # recipe 'apache', 'mysql'
-  # recipe 'recipe@version'
-  # recipe 'recipe'
-  # role ''
-  attr_reader :run_list_modifiers
-  attr_reader :run_list_removers
-  def recipe(*recipes)
-    if recipes.size == 0
-      raise ArgumentError, "At least one recipe must be specified"
-    end
-    @run_list_modifiers ||= []
-    @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-  end
-  def role(*roles)
-    if roles.size == 0
-      raise ArgumentError, "At least one role must be specified"
-    end
-    @run_list_modifiers ||= []
-    @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
-  end
-  def remove_recipe(*recipes)
-    if recipes.size == 0
-      raise ArgumentError, "At least one recipe must be specified"
-    end
-    @run_list_removers ||= []
-    @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-  end
-  def remove_role(*roles)
-    if roles.size == 0
-      raise ArgumentError, "At least one role must be specified"
-    end
-    @run_list_removers ||= []
-    @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
-  end
-end
-end
 end

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -2,103 +2,107 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 require 'chef/run_list/run_list_item'
 
-class Chef::Resource::ChefRole < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_role'
+class Chef
+  class Resource
+    class ChefRole < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_role'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
-  end
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
 
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :description, :kind_of => String
-  attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
-  attribute :env_run_lists, :kind_of => Hash
-  attribute :default_attributes, :kind_of => Hash
-  attribute :override_attributes, :kind_of => Hash
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :description, :kind_of => String
+      attribute :run_list, :kind_of => Array # We should let them specify it as a series of parameters too
+      attribute :env_run_lists, :kind_of => Hash
+      attribute :default_attributes, :kind_of => Hash
+      attribute :override_attributes, :kind_of => Hash
 
-  # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
-  # reset to their defaults)
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
+      # Specifies that this is a complete specification for the environment (i.e. attributes you don't specify will be
+      # reset to their defaults)
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
 
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-  
-  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
 
-  # default_attribute 'ip_address', '127.0.0.1'
-  # default_attribute [ 'pushy', 'port' ], '9000'
-  # default_attribute 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # default_attribute 'ip_address', :delete
-  attr_reader :default_attribute_modifiers
-  def default_attribute(attribute_path, value=NOT_PASSED, &block)
-    @default_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @default_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @default_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "default_attribute requires either a value or a block"
+      NOT_PASSED=Object.new unless defined?(NOT_PASSED)
+
+      # default_attribute 'ip_address', '127.0.0.1'
+      # default_attribute [ 'pushy', 'port' ], '9000'
+      # default_attribute 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # default_attribute 'ip_address', :delete
+      attr_reader :default_attribute_modifiers
+      def default_attribute(attribute_path, value=NOT_PASSED, &block)
+        @default_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @default_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @default_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "default_attribute requires either a value or a block"
+        end
+      end
+
+      # override_attribute 'ip_address', '127.0.0.1'
+      # override_attribute [ 'pushy', 'port' ], '9000'
+      # override_attribute 'ip_addresses' do |existing_value|
+      #   (existing_value || []) + [ '127.0.0.1' ]
+      # end
+      # override_attribute 'ip_address', :delete
+      attr_reader :override_attribute_modifiers
+      def override_attribute(attribute_path, value=NOT_PASSED, &block)
+        @override_attribute_modifiers ||= []
+        if value != NOT_PASSED
+          @override_attribute_modifiers << [ attribute_path, value ]
+        elsif block
+          @override_attribute_modifiers << [ attribute_path, block ]
+        else
+          raise "override_attribute requires either a value or a block"
+        end
+      end
+
+      # Order matters--if two things here are in the wrong order, they will be flipped in the run list
+      # recipe 'apache', 'mysql'
+      # recipe 'recipe@version'
+      # recipe 'recipe'
+      # role ''
+      attr_reader :run_list_modifiers
+      attr_reader :run_list_removers
+      def recipe(*recipes)
+        if recipes.size == 0
+          raise ArgumentError, "At least one recipe must be specified"
+        end
+        @run_list_modifiers ||= []
+        @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+      end
+      def role(*roles)
+        if roles.size == 0
+          raise ArgumentError, "At least one role must be specified"
+        end
+        @run_list_modifiers ||= []
+        @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
+      end
+      def remove_recipe(*recipes)
+        if recipes.size == 0
+          raise ArgumentError, "At least one recipe must be specified"
+        end
+        @run_list_removers ||= []
+        @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
+      end
+      def remove_role(*roles)
+        if roles.size == 0
+          raise ArgumentError, "At least one role must be specified"
+        end
+        @run_list_removers ||= []
+        @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
+      end
     end
-  end
-
-  # override_attribute 'ip_address', '127.0.0.1'
-  # override_attribute [ 'pushy', 'port' ], '9000'
-  # override_attribute 'ip_addresses' do |existing_value|
-  #   (existing_value || []) + [ '127.0.0.1' ]
-  # end
-  # override_attribute 'ip_address', :delete
-  attr_reader :override_attribute_modifiers
-  def override_attribute(attribute_path, value=NOT_PASSED, &block)
-    @override_attribute_modifiers ||= []
-    if value != NOT_PASSED
-      @override_attribute_modifiers << [ attribute_path, value ]
-    elsif block
-      @override_attribute_modifiers << [ attribute_path, block ]
-    else
-      raise "override_attribute requires either a value or a block"
-    end
-  end
-
-  # Order matters--if two things here are in the wrong order, they will be flipped in the run list
-  # recipe 'apache', 'mysql'
-  # recipe 'recipe@version'
-  # recipe 'recipe'
-  # role ''
-  attr_reader :run_list_modifiers
-  attr_reader :run_list_removers
-  def recipe(*recipes)
-    if recipes.size == 0
-      raise ArgumentError, "At least one recipe must be specified"
-    end
-    @run_list_modifiers ||= []
-    @run_list_modifiers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-  end
-  def role(*roles)
-    if roles.size == 0
-      raise ArgumentError, "At least one role must be specified"
-    end
-    @run_list_modifiers ||= []
-    @run_list_modifiers += roles.map { |role| Chef::RunList::RunListItem.new("role[#{role}]") }
-  end
-  def remove_recipe(*recipes)
-    if recipes.size == 0
-      raise ArgumentError, "At least one recipe must be specified"
-    end
-    @run_list_removers ||= []
-    @run_list_removers += recipes.map { |recipe| Chef::RunList::RunListItem.new("recipe[#{recipe}]") }
-  end
-  def remove_role(*roles)
-    if roles.size == 0
-      raise ArgumentError, "At least one role must be specified"
-    end
-    @run_list_removers ||= []
-    @run_list_removers += roles.map { |recipe| Chef::RunList::RunListItem.new("role[#{role}]") }
   end
 end

--- a/lib/chef/resource/chef_user.rb
+++ b/lib/chef/resource/chef_user.rb
@@ -1,7 +1,9 @@
 require 'cheffish'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::ChefUser < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class ChefUser < Chef::Resource::LWRPBase
   self.resource_name = 'chef_user'
 
   actions :create, :delete, :nothing
@@ -49,4 +51,6 @@ class Chef::Resource::ChefUser < Chef::Resource::LWRPBase
   def after(&block)
     block ? @after = block : @after
   end
+end
+end
 end

--- a/lib/chef/resource/chef_user.rb
+++ b/lib/chef/resource/chef_user.rb
@@ -2,55 +2,55 @@ require 'cheffish'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class ChefUser < Chef::Resource::LWRPBase
-  self.resource_name = 'chef_user'
+  class Resource
+    class ChefUser < Chef::Resource::LWRPBase
+      self.resource_name = 'chef_user'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  # Grab environment from with_environment
-  def initialize(*args)
-    super
-    chef_server run_context.cheffish.current_chef_server
+      # Grab environment from with_environment
+      def initialize(*args)
+        super
+        chef_server run_context.cheffish.current_chef_server
+      end
+
+      # Client attributes
+      attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
+      attribute :display_name, :kind_of => String
+      attribute :admin, :kind_of => [TrueClass, FalseClass]
+      attribute :email, :kind_of => String
+      attribute :external_authentication_uid
+      attribute :recovery_authentication_enabled, :kind_of => [TrueClass, FalseClass]
+      attribute :password, :kind_of => String # Hmm.  There is no way to idempotentize this.
+      #attribute :salt  # TODO server doesn't support sending or receiving these, but it's the only way to backup / restore a user
+      #attribute :hashed_password
+      #attribute :hash_type
+
+      # Input key
+      attribute :source_key # String or OpenSSL::PKey::*
+      attribute :source_key_path, :kind_of => String
+      attribute :source_key_pass_phrase
+
+      # Output public key (if so desired)
+      attribute :output_key_path, :kind_of => String
+      attribute :output_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
+
+      # If this is set, client is not patchy
+      attribute :complete, :kind_of => [TrueClass, FalseClass]
+
+      attribute :raw_json, :kind_of => Hash
+      attribute :chef_server, :kind_of => Hash
+
+      # Proc that runs just before the resource executes.  Called with (resource)
+      def before(&block)
+        block ? @before = block : @before
+      end
+
+      # Proc that runs after the resource completes.  Called with (resource, json, private_key, public_key)
+      def after(&block)
+        block ? @after = block : @after
+      end
+    end
   end
-
-  # Client attributes
-  attribute :name, :kind_of => String, :regex => Cheffish::NAME_REGEX, :name_attribute => true
-  attribute :display_name, :kind_of => String
-  attribute :admin, :kind_of => [TrueClass, FalseClass]
-  attribute :email, :kind_of => String
-  attribute :external_authentication_uid
-  attribute :recovery_authentication_enabled, :kind_of => [TrueClass, FalseClass]
-  attribute :password, :kind_of => String # Hmm.  There is no way to idempotentize this.
-  #attribute :salt  # TODO server doesn't support sending or receiving these, but it's the only way to backup / restore a user
-  #attribute :hashed_password
-  #attribute :hash_type
-
-  # Input key
-  attribute :source_key # String or OpenSSL::PKey::*
-  attribute :source_key_path, :kind_of => String
-  attribute :source_key_pass_phrase
-
-  # Output public key (if so desired)
-  attribute :output_key_path, :kind_of => String
-  attribute :output_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
-
-  # If this is set, client is not patchy
-  attribute :complete, :kind_of => [TrueClass, FalseClass]
-
-  attribute :raw_json, :kind_of => Hash
-  attribute :chef_server, :kind_of => Hash
-
-  # Proc that runs just before the resource executes.  Called with (resource)
-  def before(&block)
-    block ? @before = block : @before
-  end
-
-  # Proc that runs after the resource completes.  Called with (resource, json, private_key, public_key)
-  def after(&block)
-    block ? @after = block : @after
-  end
-end
-end
 end

--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -2,47 +2,47 @@ require 'openssl/cipher'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class PrivateKey < Chef::Resource::LWRPBase
-  self.resource_name = 'private_key'
+  class Resource
+    class PrivateKey < Chef::Resource::LWRPBase
+      self.resource_name = 'private_key'
 
-  actions :create, :delete, :regenerate, :nothing
-  default_action :create
+      actions :create, :delete, :regenerate, :nothing
+      default_action :create
 
-  # Path to private key.  Set to :none to create the key in memory and not on disk.
-  attribute :path, :kind_of => [ String, Symbol ], :name_attribute => true
-  attribute :format, :kind_of => Symbol, :default => :pem, :equal_to => [ :pem, :der ]
-  attribute :type, :kind_of => Symbol, :default => :rsa, :equal_to => [ :rsa, :dsa ] # TODO support :ec
-  # These specify an optional public_key you can spit out if you want.
-  attribute :public_key_path, :kind_of => String
-  attribute :public_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :openssh, :pem, :der ]
-  # Specify this if you want to copy another private key but give it a different format / password
-  attribute :source_key
-  attribute :source_key_path, :kind_of => String
-  attribute :source_key_pass_phrase
+      # Path to private key.  Set to :none to create the key in memory and not on disk.
+      attribute :path, :kind_of => [ String, Symbol ], :name_attribute => true
+      attribute :format, :kind_of => Symbol, :default => :pem, :equal_to => [ :pem, :der ]
+      attribute :type, :kind_of => Symbol, :default => :rsa, :equal_to => [ :rsa, :dsa ] # TODO support :ec
+      # These specify an optional public_key you can spit out if you want.
+      attribute :public_key_path, :kind_of => String
+      attribute :public_key_format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :openssh, :pem, :der ]
+      # Specify this if you want to copy another private key but give it a different format / password
+      attribute :source_key
+      attribute :source_key_path, :kind_of => String
+      attribute :source_key_pass_phrase
 
-  # RSA and DSA
-  attribute :size, :kind_of => Integer, :default => 2048
+      # RSA and DSA
+      attribute :size, :kind_of => Integer, :default => 2048
 
-  # RSA-only
-  attribute :exponent, :kind_of => Integer # For RSA
+      # RSA-only
+      attribute :exponent, :kind_of => Integer # For RSA
 
-  # PEM-only
-  attribute :pass_phrase, :kind_of => String
-  attribute :cipher, :kind_of => String, :default => 'DES-EDE3-CBC', :equal_to => OpenSSL::Cipher.ciphers
+      # PEM-only
+      attribute :pass_phrase, :kind_of => String
+      attribute :cipher, :kind_of => String, :default => 'DES-EDE3-CBC', :equal_to => OpenSSL::Cipher.ciphers
 
-  # Set this to regenerate the key if it does not have the desired characteristics (like size, type, etc.)
-  attribute :regenerate_if_different, :kind_of => [TrueClass, FalseClass]
+      # Set this to regenerate the key if it does not have the desired characteristics (like size, type, etc.)
+      attribute :regenerate_if_different, :kind_of => [TrueClass, FalseClass]
 
-  # Proc that runs after the resource completes.  Called with (resource, private_key)
-  def after(&block)
-    block ? @after = block : @after
+      # Proc that runs after the resource completes.  Called with (resource, private_key)
+      def after(&block)
+        block ? @after = block : @after
+      end
+
+      # We are not interested in Chef's cloning behavior here.
+      def load_prior_resource(*args)
+        Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
+      end
+    end
   end
-
-  # We are not interested in Chef's cloning behavior here.
-  def load_prior_resource(*args)
-    Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
-  end
-end
-end
 end

--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -1,7 +1,9 @@
 require 'openssl/cipher'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::PrivateKey < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class PrivateKey < Chef::Resource::LWRPBase
   self.resource_name = 'private_key'
 
   actions :create, :delete, :regenerate, :nothing
@@ -41,4 +43,6 @@ class Chef::Resource::PrivateKey < Chef::Resource::LWRPBase
   def load_prior_resource(*args)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
   end
+end
+end
 end

--- a/lib/chef/resource/public_key.rb
+++ b/lib/chef/resource/public_key.rb
@@ -1,7 +1,9 @@
 require 'openssl/cipher'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource::PublicKey < Chef::Resource::LWRPBase
+class Chef
+class Resource
+class PublicKey < Chef::Resource::LWRPBase
   self.resource_name = 'public_key'
 
   actions :create, :delete, :nothing
@@ -18,4 +20,6 @@ class Chef::Resource::PublicKey < Chef::Resource::LWRPBase
   def load_prior_resource(*args)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
   end
+end
+end
 end

--- a/lib/chef/resource/public_key.rb
+++ b/lib/chef/resource/public_key.rb
@@ -2,24 +2,24 @@ require 'openssl/cipher'
 require 'chef/resource/lwrp_base'
 
 class Chef
-class Resource
-class PublicKey < Chef::Resource::LWRPBase
-  self.resource_name = 'public_key'
+  class Resource
+    class PublicKey < Chef::Resource::LWRPBase
+      self.resource_name = 'public_key'
 
-  actions :create, :delete, :nothing
-  default_action :create
+      actions :create, :delete, :nothing
+      default_action :create
 
-  attribute :path, :kind_of => String, :name_attribute => true
-  attribute :format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
+      attribute :path, :kind_of => String, :name_attribute => true
+      attribute :format, :kind_of => Symbol, :default => :openssh, :equal_to => [ :pem, :der, :openssh ]
 
-  attribute :source_key
-  attribute :source_key_path, :kind_of => String
-  attribute :source_key_pass_phrase
+      attribute :source_key
+      attribute :source_key_path, :kind_of => String
+      attribute :source_key_pass_phrase
 
-  # We are not interested in Chef's cloning behavior here.
-  def load_prior_resource(*args)
-    Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
+      # We are not interested in Chef's cloning behavior here.
+      def load_prior_resource(*args)
+        Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
+      end
+    end
   end
-end
-end
 end

--- a/lib/cheffish.rb
+++ b/lib/cheffish.rb
@@ -113,6 +113,8 @@ module Cheffish
     nil
   end
 
+  # `NOT_PASSED` is defined in chef-12.5.0, this guard will ensure we
+  # don't redefine it if it's already there
   NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   def self.node_attributes(klass)

--- a/lib/cheffish.rb
+++ b/lib/cheffish.rb
@@ -113,7 +113,7 @@ module Cheffish
     nil
   end
 
-  NOT_PASSED=Object.new
+  NOT_PASSED=Object.new unless defined?(NOT_PASSED)
 
   def self.node_attributes(klass)
     klass.class_eval do

--- a/spec/integration/chef_role_spec.rb
+++ b/spec/integration/chef_role_spec.rb
@@ -1,0 +1,78 @@
+require 'support/spec_support'
+require 'cheffish/rspec/chef_run_support'
+require 'chef/resource/chef_role'
+require 'chef/provider/chef_role'
+
+describe Chef::Resource::ChefRole do
+  extend Cheffish::RSpec::ChefRunSupport
+
+  when_the_chef_12_server 'is in multi-org mode' do
+    organization 'foo'
+
+    before :each do
+      Chef::Config.chef_server_url = URI.join(Chef::Config.chef_server_url, '/organizations/foo').to_s
+    end
+
+    context 'and is empty' do
+      context 'and we run a recipe that creates role "blah"' do
+        it 'the role gets created' do
+          expect_recipe {
+            chef_role 'blah'
+          }.to have_updated 'chef_role[blah]', :create
+          expect(get('roles/blah')['name']).to eq('blah')
+        end
+      end
+
+      # TODO why-run mode
+
+      context 'and another chef server is running on port 8899' do
+        before :each do
+          @server = ChefZero::Server.new(:port => 8899)
+          @server.start_background
+        end
+
+        after :each do
+          @server.stop
+        end
+
+        context 'and a recipe is run that creates role "blah" on the second chef server using with_chef_server' do
+
+          it 'the role is created on the second chef server but not the first' do
+            expect_recipe {
+              with_chef_server 'http://127.0.0.1:8899'
+              chef_role 'blah'
+            }.to have_updated 'chef_role[blah]', :create
+            expect { get('roles/blah') }.to raise_error(Net::HTTPServerException)
+            expect(get('http://127.0.0.1:8899/roles/blah')['name']).to eq('blah')
+          end
+        end
+
+        context 'and a recipe is run that creates role "blah" on the second chef server using chef_server' do
+
+          it 'the role is created on the second chef server but not the first' do
+            expect_recipe {
+              chef_role 'blah' do
+                chef_server({ :chef_server_url => 'http://127.0.0.1:8899' })
+              end
+            }.to have_updated 'chef_role[blah]', :create
+            expect { get('roles/blah') }.to raise_error(Net::HTTPServerException)
+            expect(get('http://127.0.0.1:8899/roles/blah')['name']).to eq('blah')
+          end
+        end
+      end
+    end
+  end
+
+  when_the_chef_server 'is in OSC mode' do
+    context 'and is empty' do
+      context 'and we run a recipe that creates role "blah"' do
+        it 'the role gets created' do
+          expect_recipe {
+            chef_role 'blah'
+          }.to have_updated 'chef_role[blah]', :create
+          expect(get('roles/blah')['name']).to eq('blah')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit modified the way we create the `Resources` and `Providers` inside `Cheffish`.

Instead of creating them as:
```
class Chef::Resource::Blah
```

We now use:
```
class Chef
class Resource
class Blah
```

The same for the Providers.

The main reason for this is to open Chef class and consume what is in there. In this case the `NOT_PASSED` constant! We also check that the `NOT_PASSED` constant is not defined before declaring it.

This was failing on `chefdk` with chef version `chef-12.5.0`

Here the snippet of the error:
```
[1] pry(#<Chef::Recipe>)> my_role = chef_role 'salim'
=> #<Chef::Resource::ChefRole:0x3fe2ed1f4b44>
[2] pry(#<Chef::Recipe>)> my_role.run_action(:create)
Chef::Exceptions::ValidationFailed: Option name's value #<Object:0x007fc5da8cfdc8> does not match regular expression /^[.\-[:alnum:]_]+$/
from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.0.current.0/lib/chef/mixin/params_validate.rb:299:in `_pv_regex'
```