### PR TITLE
Make cheffish not depend on the chef gem.

### DIFF
--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/chef/cheffish'
 
   s.add_dependency 'chef-zero', '~> 4.2'
-  s.add_dependency 'chef' , '~> 12.2'
 
+  s.add_development_dependency 'chef', '~> 12.2'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.bindir       = "bin"


### PR DESCRIPTION
We don't want plugins to depend on chef and pull
in such gependencies when they are gem installed.