### PR TITLE
Override to_h to call to_hash method.

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -87,6 +87,10 @@ module Cheffish
       result
     end
 
+    def to_h
+      to_hash
+    end
+
     def to_s
       to_hash.to_s
     end


### PR DESCRIPTION
Fixes an issue where to_h returns nil instead of a hash.

```
irb(main):003:0> require 'cheffish'
irb(main):004:0> mc = Cheffish::MergedConfig.new
irb(main):005:0> mc.to_h
=> nil
```

```
ruby --version
ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.5.0]
```

Prevents aws local balancer creation from working properly https://github.com/chef/chef-provisioning-aws/blob/master/lib/chef/provisioning/aws_driver/driver.rb#L123
