### PR TITLE
proxying to_h to to_hash

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -87,6 +87,10 @@ module Cheffish
       result
     end
 
+    def to_h
+      to_hash
+    end
+
     def to_s
       to_hash.to_s
     end


### PR DESCRIPTION
Using Ruby 2.0.0, `to_h` wasn't getting automatically proxied to `to_hash` - this fixes that.