### PR TITLE
Make NodeProperties work with chef-provisioning

### DIFF
--- a/lib/cheffish/base_properties.rb
+++ b/lib/cheffish/base_properties.rb
@@ -1,0 +1,21 @@
+require 'chef_compat/mixin/properties'
+require 'cheffish/array_property'
+require 'cheffish'
+
+module Cheffish
+  module BaseProperties
+    include ChefCompat::Mixin::Properties
+
+    def initialize(*args)
+      super
+      chef_server run_context.cheffish.current_chef_server
+    end
+
+    Boolean = property_type(is: [ true, false ])
+    ArrayType = ArrayProperty.new
+
+    property :chef_server, Hash
+    property :raw_json, Hash
+    property :complete, Boolean
+  end
+end

--- a/lib/cheffish/base_resource.rb
+++ b/lib/cheffish/base_resource.rb
@@ -1,19 +1,9 @@
 require 'chef_compat/resource'
-require 'cheffish/array_property'
+require 'cheffish/base_properties'
 
 module Cheffish
   class BaseResource < ChefCompat::Resource
-    def initialize(*args)
-      super
-      chef_server run_context.cheffish.current_chef_server
-    end
-
-    Boolean = property_type(is: [ true, false ])
-    ArrayType = ArrayProperty.new
-
-    property :chef_server, Hash
-    property :raw_json, Hash
-    property :complete, Boolean
+    include Cheffish::BaseProperties
 
     declare_action_class.class_eval do
       def rest

--- a/lib/cheffish/node_properties.rb
+++ b/lib/cheffish/node_properties.rb
@@ -1,8 +1,8 @@
-require 'chef_compat/mixin/properties'
+require 'cheffish/base_properties'
 
 module Cheffish
   module NodeProperties
-    include ChefCompat::Mixin::Properties
+    include Cheffish::BaseProperties
 
     # Grab environment from with_environment
     def initialize(*args)


### PR DESCRIPTION
ChefProvisioning::Machine includes NodeProperties, which needs to have `chef_server` property in it.