### PR TITLE
fix object model insanity

### DIFF
--- a/lib/cheffish/basic_chef_client.rb
+++ b/lib/cheffish/basic_chef_client.rb
@@ -48,7 +48,6 @@ module Cheffish
     attr_reader :run_context
     attr_accessor :cookbook_name
     attr_accessor :recipe_name
-    def_delegators :@run_context, :resource_collection, :immediate_notifications, :delayed_notifications
 
     def add_resource(resource)
       with_chef_config do
@@ -66,7 +65,7 @@ module Cheffish
 
     def converge
       with_chef_config do
-        Chef::Runner.new(self).converge
+        Chef::Runner.new(run_context).converge
       end
     end
 

--- a/lib/cheffish/chef_run.rb
+++ b/lib/cheffish/chef_run.rb
@@ -73,7 +73,7 @@ module Cheffish
     end
 
     def resources
-      client.resource_collection
+      client.run_context.resource_collection
     end
 
     def compile_recipe(&recipe)


### PR DESCRIPTION
Chef::Runner takes the Chef::RunContext as its argument.  This class is
supposed to be an analogue of Chef::Client but its injecting *itself*
into the Chef::Runner, it then has to proxy all the messages that the
Chef::Runner makes to to the Chef::RunContext which creates hugely tight
coupling between this class and the already tightly coupled Chef::Runner
and Chef::RunContext classes.

(It becomes an object with the interface and responsibility of Chef::Client and Chef::RunContext which is just a big pile of NOPE)