### PR TITLE
Use server_api: 0 for cheffish spec requests (since the software does…

### DIFF
--- a/lib/cheffish/rspec/chef_run_support.rb
+++ b/lib/cheffish/rspec/chef_run_support.rb
@@ -33,7 +33,7 @@ module Cheffish
 
       module ChefRunSupportInstanceMethods
         def rest
-          ::Chef::ServerAPI.new
+          ::Chef::ServerAPI.new(Chef::Config.chef_server_url, api_version: "0")
         end
 
         def get(path, *args)


### PR DESCRIPTION
… that too)