### PR TITLE
Cleaning up some provisioning warnings

### DIFF
--- a/lib/chef/resource/chef_data_bag_item.rb
+++ b/lib/chef/resource/chef_data_bag_item.rb
@@ -37,7 +37,13 @@ class Chef
       property :raw_data, Hash
 
       # If secret or secret_path are set, encrypt is assumed true.  encrypt exists mainly for with_secret and with_secret_path
-      property :encrypt, Boolean, default: lazy { secret || secret_path }
+      property :encrypt, Boolean, default: lazy {
+        if secret.nil? && secret_path.nil?
+          false
+        else
+          true
+        end
+      }
       property :secret, String
       property :secret_path, String
       property :encryption_version, Integer
@@ -165,8 +171,8 @@ class Chef
 
             # There are no encryptable values, so pretend encryption is the same as desired
 
-            current_resource.encrypt new_resource.encrypt
-            current_resource.encryption_version new_resource.encryption_version
+            current_resource.encrypt(new_resource.encrypt) unless new_resource.encrypt.nil?
+            current_resource.encryption_version(new_resource.encryption_version) if new_resource.encryption_version
             if new_resource.secret || new_resource.secret_path
               current_resource.secret new_secret
             end

--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -239,11 +239,11 @@ class Chef
               if key
                 @current_private_key = key
                 resource.format key_format[:format]
-                resource.type key_format[:type]
-                resource.size key_format[:size]
-                resource.exponent key_format[:exponent]
-                resource.pass_phrase key_format[:pass_phrase]
-                resource.cipher key_format[:cipher]
+                resource.type(key_format[:type]) if key_format[:type]
+                resource.size(key_format[:size]) if key_format[:size]
+                resource.exponent(key_format[:exponent]) if key_format[:exponent]
+                resource.pass_phrase(key_format[:pass_phrase]) if key_format[:pass_phrase]
+                resource.cipher(key_format[:cipher]) if key_format[:cipher]
               end
             rescue
               # If there's an error reading, we assume format and type are wrong and don't futz with them

--- a/lib/cheffish/key_formatter.rb
+++ b/lib/cheffish/key_formatter.rb
@@ -23,7 +23,7 @@ module Cheffish
         end
       end
 
-      key_format[:type] = type_of(key)
+      key_format[:type] = type_of(key) if type_of(key)
       key_format[:size] = size_of(key) if size_of(key)
       key_format[:pass_phrase] = pass_phrase if pass_phrase
       # TODO cipher, exponent
@@ -94,19 +94,21 @@ module Cheffish
 
     def self.type_of(key)
       case key.class
-      when OpenSSL::PKey::RSA
-        :rsa
-      when OpenSSL::PKey::DSA
-        :dsa
+        when OpenSSL::PKey::RSA
+          :rsa
+        when OpenSSL::PKey::DSA
+          :dsa
+        else
+          nil
       end
     end
 
     def self.size_of(key)
       case key.class
-      when OpenSSL::PKey::RSA
-        key.n.num_bytes * 8
-      else
-        nil
+        when OpenSSL::PKey::RSA
+          key.n.num_bytes * 8
+        else
+          nil
       end
     end
   end


### PR DESCRIPTION
Fixes warnings like https://github.com/chef/cheffish/issues/95

```
[2016-07-28T11:34:40-06:00] WARN: Default value nil is invalid for property encrypt of resource chef_data_bag_item. Possible fixes: 1. Remove 'default: nil' if nil means 'undefined'. 2. Set a valid default value if there is a reasonable one. 3. Allow nil as a valid value of your property (for example, 'property :encrypt, [ String, nil ], default: nil'). Error: Property encrypt must be one of: true, false!  You passed nil. at /Users/tball/github/cheffish/lib/chef/resource/chef_data_bag_item.rb:189:in `new_encrypt'
```

\cc @jkeiser @chef/provisioning 