### PR TITLE
MergedConfig: Support both string & symbol for []

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -24,7 +24,7 @@ module Cheffish
       else
         result_configs = []
         configs.each do |config|
-          value = config[name]
+          value = config[name.to_s] || config[name.to_sym]
           if !value.nil?
             if value.respond_to?(:keys)
               result_configs << value


### PR DESCRIPTION
When you have a MergedConfig with two config defining the 'same' key, but one as a string and one as a symbol, you end up having this very confusing behavior:

```ruby
config['bootstrap_options']
=> {some hash}
config[:bootstrap_options]
=> {another hash}
```

This PR address this behavior. I hope but doubt this is an appropriate fix, so let me know what you think about it