### PR TITLE
MergedConfig: Use Chef::Mash as storage

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -1,8 +1,10 @@
+require "chef/mash"
+
 module Cheffish
   class MergedConfig
     def initialize(*configs)
-      @configs = configs
-      @merge_arrays = {}
+      @configs = configs.map { |config| Chef::Mash.from_hash config }
+      @merge_arrays = Chef::Mash.new
     end
 
     include Enumerable

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -6,6 +6,24 @@ describe "merged_config" do
     Cheffish::MergedConfig.new({ :test => "val" })
   end
 
+  let(:collision) do
+    c1 = { :test1 => "c1.1", "test2" => "c1.2" }
+    c2 = { "test1" => "c2.1", "test3" => "c2.3" }
+    Cheffish::MergedConfig.new(c1, c2)
+  end
+
+  let(:config_mismatch) do
+    c1 = { :test => { :test => "val" } }
+    c2 = { :test => [2, 3, 4] }
+    Cheffish::MergedConfig.new(c1, c2)
+  end
+
+  let(:config_hashes) do
+    c1 = { :test => { :test => "val" } }
+    c2 = { :test => { :test2 => "val2" } }
+    Cheffish::MergedConfig.new(c1, c2)
+  end
+
   it "returns value in config" do
     expect(config.test).to eq("val")
   end
@@ -15,6 +33,28 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect("#{config}").to eq("{:test=>\"val\"}")
+    expect("#{config}").to eq("{\"test\"=>\"val\"}")
+  end
+
+  it "has indifferent str/sym access" do
+    expect(config["test"]).to eq("val")
+  end
+
+  it "respects precedence between the different configs" do
+    expect(collision["test1"]).to eq("c1.1")
+    expect(collision[:test1]).to eq("c1.1")
+  end
+
+  it "merges the configs" do
+    expect(collision[:test2]).to eq("c1.2")
+    expect(collision[:test3]).to eq("c2.3")
+  end
+
+  it "handle merged value type mismatch" do
+    expect(config_mismatch[:test]).to eq("test" => "val")
+  end
+
+  it "merges values when they're hashes" do
+    expect(config_hashes[:test].keys).to eq(%w{test test2})
   end
 end


### PR DESCRIPTION
When you have a MergedConfig with two config defining the 'same' key, but one as a string and one as a symbol, you end up having this very confusing behavior:

```ruby
config['bootstrap_options']
=> {some hash}
config[:bootstrap_options]
=> {another hash}
```

This PR address this behavior. I hope but doubt this is an appropriate fix, so let me know what you think about it

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>