### PR TITLE
Avoid redefining the Chef::Resource#name method

### DIFF
--- a/lib/chef/resource/chef_client.rb
+++ b/lib/chef/resource/chef_client.rb
@@ -7,7 +7,7 @@ class Chef
       resource_name :chef_client
 
       # Client attributes
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :chef_client_name, Cheffish::NAME_REGEX, name_property: true
       property :admin, Boolean
       property :validator, Boolean
 
@@ -61,7 +61,7 @@ class Chef
 
         def keys
           {
-            'name' => :name,
+            'name' => :chef_client_name,
             'admin' => :admin,
             'validator' => :validator,
             'public_key' => :source_key

--- a/lib/chef/resource/chef_container.rb
+++ b/lib/chef/resource/chef_container.rb
@@ -7,11 +7,11 @@ class Chef
     class ChefContainer < Cheffish::BaseResource
       resource_name :chef_container
 
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :chef_container_name, Cheffish::NAME_REGEX, name_property: true
 
       action :create do
         if !@current_exists
-          converge_by "create container #{new_resource.name} at #{rest.url}" do
+          converge_by "create container #{new_resource.chef_container_name} at #{rest.url}" do
             rest.post("containers", normalize_for_post(new_json))
           end
         end
@@ -19,8 +19,8 @@ class Chef
 
       action :delete do
         if @current_exists
-          converge_by "delete container #{new_resource.name} at #{rest.url}" do
-            rest.delete("containers/#{new_resource.name}")
+          converge_by "delete container #{new_resource.chef_container_name} at #{rest.url}" do
+            rest.delete("containers/#{new_resource.chef_container_name}")
           end
         end
       end
@@ -28,7 +28,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           begin
-            @current_exists = rest.get("containers/#{new_resource.name}")
+            @current_exists = rest.get("containers/#{new_resource.chef_container_name}")
           rescue Net::HTTPServerException => e
             if e.response.code == "404"
               @current_exists = false
@@ -47,7 +47,7 @@ class Chef
         end
 
         def keys
-          { 'containername' => :name, 'containerpath' => :name }
+          { 'containername' => :chef_container_name, 'containerpath' => :chef_container_name }
         end
       end
     end

--- a/lib/chef/resource/chef_data_bag.rb
+++ b/lib/chef/resource/chef_data_bag.rb
@@ -6,20 +6,20 @@ class Chef
     class ChefDataBag < Cheffish::BaseResource
       resource_name :chef_data_bag
 
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :data_bag_name, Cheffish::NAME_REGEX, name_property: true
 
       action :create do
         if !current_resource_exists?
-          converge_by "create data bag #{new_resource.name} at #{rest.url}" do
-            rest.post("data", { 'name' => new_resource.name })
+          converge_by "create data bag #{new_resource.data_bag_name} at #{rest.url}" do
+            rest.post("data", { 'name' => new_resource.data_bag_name })
           end
         end
       end
 
       action :delete do
         if current_resource_exists?
-          converge_by "delete data bag #{new_resource.name} at #{rest.url}" do
-            rest.delete("data/#{new_resource.name}")
+          converge_by "delete data bag #{new_resource.data_bag_name} at #{rest.url}" do
+            rest.delete("data/#{new_resource.data_bag_name}")
           end
         end
       end
@@ -27,7 +27,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           begin
-            @current_resource = json_to_resource(rest.get("data/#{new_resource.name}"))
+            @current_resource = json_to_resource(rest.get("data/#{new_resource.data_bag_name}"))
           rescue Net::HTTPServerException => e
             if e.response.code == "404"
               @current_resource = not_found_resource

--- a/lib/chef/resource/chef_environment.rb
+++ b/lib/chef/resource/chef_environment.rb
@@ -8,7 +8,7 @@ class Chef
     class ChefEnvironment < Cheffish::BaseResource
       resource_name :chef_environment
 
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :environment_name, Cheffish::NAME_REGEX, name_property: true
       property :description, String
       property :cookbook_versions, Hash, callbacks: {
         "should have valid cookbook versions" => lambda { |value| Chef::Environment.validate_cookbook_versions(value) }
@@ -61,13 +61,13 @@ class Chef
 
         if current_resource_exists?
           if differences.size > 0
-            description = [ "update environment #{new_resource.name} at #{rest.url}" ] + differences
+            description = [ "update environment #{new_resource.environment_name} at #{rest.url}" ] + differences
             converge_by description do
-              rest.put("environments/#{new_resource.name}", normalize_for_put(new_json))
+              rest.put("environments/#{new_resource.environment_name}", normalize_for_put(new_json))
             end
           end
         else
-          description = [ "create environment #{new_resource.name} at #{rest.url}" ] + differences
+          description = [ "create environment #{new_resource.environment_name} at #{rest.url}" ] + differences
           converge_by description do
             rest.post("environments", normalize_for_post(new_json))
           end
@@ -76,8 +76,8 @@ class Chef
 
       action :delete do
         if current_resource_exists?
-          converge_by "delete environment #{new_resource.name} at #{rest.url}" do
-            rest.delete("environments/#{new_resource.name}")
+          converge_by "delete environment #{new_resource.environment_name} at #{rest.url}" do
+            rest.delete("environments/#{new_resource.environment_name}")
           end
         end
       end
@@ -85,7 +85,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           begin
-            @current_resource = json_to_resource(rest.get("environments/#{new_resource.name}"))
+            @current_resource = json_to_resource(rest.get("environments/#{new_resource.environment_name}"))
           rescue Net::HTTPServerException => e
             if e.response.code == "404"
               @current_resource = not_found_resource
@@ -116,7 +116,7 @@ class Chef
 
         def keys
           {
-            'name' => :name,
+            'name' => :environment_name,
             'description' => :description,
             'cookbook_versions' => :cookbook_versions,
             'default_attributes' => :default_attributes,

--- a/lib/chef/resource/chef_group.rb
+++ b/lib/chef/resource/chef_group.rb
@@ -8,7 +8,7 @@ class Chef
     class ChefGroup < Cheffish::BaseResource
       resource_name :chef_group
 
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :group_name, Cheffish::NAME_REGEX, name_property: true
       property :users, ArrayType
       property :clients, ArrayType
       property :groups, ArrayType
@@ -21,13 +21,13 @@ class Chef
 
         if current_resource_exists?
           if differences.size > 0
-            description = [ "update group #{new_resource.name} at #{rest.url}" ] + differences
+            description = [ "update group #{new_resource.group_name} at #{rest.url}" ] + differences
             converge_by description do
-              rest.put("groups/#{new_resource.name}", normalize_for_put(new_json))
+              rest.put("groups/#{new_resource.group_name}", normalize_for_put(new_json))
             end
           end
         else
-          description = [ "create group #{new_resource.name} at #{rest.url}" ] + differences
+          description = [ "create group #{new_resource.group_name} at #{rest.url}" ] + differences
           converge_by description do
             rest.post("groups", normalize_for_post(new_json))
           end
@@ -36,8 +36,8 @@ class Chef
 
       action :delete do
         if current_resource_exists?
-          converge_by "delete group #{new_resource.name} at #{rest.url}" do
-            rest.delete("groups/#{new_resource.name}")
+          converge_by "delete group #{new_resource.group_name} at #{rest.url}" do
+            rest.delete("groups/#{new_resource.group_name}")
           end
         end
       end
@@ -45,7 +45,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           begin
-            @current_resource = json_to_resource(rest.get("groups/#{new_resource.name}"))
+            @current_resource = json_to_resource(rest.get("groups/#{new_resource.group_name}"))
           rescue Net::HTTPServerException => e
             if e.response.code == "404"
               @current_resource = not_found_resource
@@ -80,8 +80,8 @@ class Chef
 
         def keys
           {
-            'name' => :name,
-            'groupname' => :name
+            'name' => :group_name,
+            'groupname' => :group_name
           }
         end
       end

--- a/lib/chef/resource/chef_mirror.rb
+++ b/lib/chef/resource/chef_mirror.rb
@@ -33,7 +33,21 @@ class Chef
       property :purge, Boolean
 
       # Whether to freeze cookbooks on upload
-      property :freeze, Boolean
+      property :freeze_on_upload, Boolean
+
+      # `freeze` is an already-existing instance method on Object, so we can't use it or we'll throw
+      # a deprecation warning. `freeze` has been renamed to `freeze_on_upload` and this method
+      # is here to log a deprecation warning.
+      def freeze(arg = nil)
+        Chef::Log.warn("Property `freeze` on the `chef_mirror` resource has changed to `freeze_on_upload`." \
+          "Please use `freeze_on_upload` instead. This will raise an exception in a future version of the cheffish gem.")
+
+        set_or_return(
+          :freeze_on_upload,
+          arg,
+          :kind_of => Boolean
+        )
+      end
 
       # If this is true, only new files will be copied.  File contents will not be
       # diffed, so changed files will never be uploaded.
@@ -156,7 +170,7 @@ class Chef
         def options
           result = {
             :purge => new_resource.purge,
-            :freeze => new_resource.freeze,
+            :freeze => new_resource.freeze_on_upload,
             :diff => new_resource.no_diff,
             :dry_run => whyrun_mode?
           }

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -8,7 +8,7 @@ class Chef
     class ChefRole < Cheffish::BaseResource
       resource_name :chef_role
 
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :role_name, Cheffish::NAME_REGEX, name_property: true
       property :description, String
       property :run_list, Array # We should let them specify it as a series of parameters too
       property :env_run_lists, Hash
@@ -92,13 +92,13 @@ class Chef
 
         if current_resource_exists?
           if differences.size > 0
-            description = [ "update role #{new_resource.name} at #{rest.url}" ] + differences
+            description = [ "update role #{new_resource.role_name} at #{rest.url}" ] + differences
             converge_by description do
-              rest.put("roles/#{new_resource.name}", normalize_for_put(new_json))
+              rest.put("roles/#{new_resource.role_name}", normalize_for_put(new_json))
             end
           end
         else
-          description = [ "create role #{new_resource.name} at #{rest.url}" ] + differences
+          description = [ "create role #{new_resource.role_name} at #{rest.url}" ] + differences
           converge_by description do
             rest.post("roles", normalize_for_post(new_json))
           end
@@ -107,8 +107,8 @@ class Chef
 
       action :delete do
         if current_resource_exists?
-          converge_by "delete role #{new_resource.name} at #{rest.url}" do
-            rest.delete("roles/#{new_resource.name}")
+          converge_by "delete role #{new_resource.role_name} at #{rest.url}" do
+            rest.delete("roles/#{new_resource.role_name}")
           end
         end
       end
@@ -116,7 +116,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           begin
-            @current_resource = json_to_resource(rest.get("roles/#{new_resource.name}"))
+            @current_resource = json_to_resource(rest.get("roles/#{new_resource.role_name}"))
           rescue Net::HTTPServerException => e
             if e.response.code == "404"
               @current_resource = not_found_resource
@@ -148,7 +148,7 @@ class Chef
 
         def keys
           {
-            'name' => :name,
+            'name' => :role_name,
             'description' => :description,
             'run_list' => :run_list,
             'env_run_lists' => :env_run_lists,

--- a/lib/chef/resource/chef_user.rb
+++ b/lib/chef/resource/chef_user.rb
@@ -7,7 +7,7 @@ class Chef
       resource_name :chef_user
 
       # Client attributes
-      property :name, Cheffish::NAME_REGEX, name_property: true
+      property :user_name, Cheffish::NAME_REGEX, name_property: true
       property :display_name, String
       property :admin, Boolean
       property :email, String
@@ -70,8 +70,8 @@ class Chef
 
         def keys
           {
-            'name' => :name,
-            'username' => :name,
+            'name' => :user_name,
+            'username' => :user_name,
             'display_name' => :display_name,
             'admin' => :admin,
             'email' => :email,

--- a/lib/cheffish/node_properties.rb
+++ b/lib/cheffish/node_properties.rb
@@ -10,7 +10,7 @@ module Cheffish
       chef_environment run_context.cheffish.current_environment
     end
 
-    property :name, Cheffish::NAME_REGEX, name_property: true
+    property :node_properties_name, Cheffish::NAME_REGEX, name_property: true
     property :chef_environment, Cheffish::NAME_REGEX
     property :run_list, Array # We should let them specify it as a series of parameters too
     property :attributes, Hash


### PR DESCRIPTION
In chef/chef#5606, Chef will now log deprecation warnings whenever
a resource defines a property that is already an instance_method
on that resource. If this happens, a user may be inadvertently
causing unexpected and difficult-to-troubleshoot behavior.

A number of the cheffish resources were defining a `name` property
which is already a property defined on the Chef::Resource base class.
This change stops defining the `name` property for each of these
resources and instead defines something unique.

In addition, the `chef_mirror` resource defined a `freeze` property
which is already an instance_method on `Object` instances. I have
changed that to be `freeze_on_upload` and defined a method to log
a deprecation warning while providing backward compatibility.