### PR TITLE
Adding a symbolize_keys method to MergedConfig

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,6 @@ if ENV["GEMFILE_MOD"]
 else
   group :development do
     gem "chef", git: "https://github.com/chef/chef" # until a version allowing chef-zero 5 is released
+    gem "ohai", git: "https://github.com/chef/ohai" # until Chef 13 and Ohai 13 are released
   end
 end

--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -3,8 +3,8 @@ require "chef/mash"
 module Cheffish
   class MergedConfig
     def initialize(*configs)
-      @configs = configs.map { |config| Chef::Mash.from_hash config }
-      @merge_arrays = Chef::Mash.new
+      @configs = configs.map { |config| ::Mash.from_hash config }
+      @merge_arrays = ::Mash.new
     end
 
     include Enumerable
@@ -95,6 +95,14 @@ module Cheffish
 
     def to_s
       to_hash.to_s
+    end
+
+    def symbolize_keys
+      result = {}
+      each_pair do |key, value|
+        result[key.to_sym] = value
+      end
+      result
     end
   end
 end

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -57,4 +57,12 @@ describe "merged_config" do
   it "merges values when they're hashes" do
     expect(config_hashes[:test].keys).to eq(%w{test test2})
   end
+
+  it "can convert to a hash" do
+    expect(config.to_h).to eq({"test"=>"val"})
+  end
+
+  it "can convert to a hash with symbol keys" do
+    expect(config.symbolize_keys).to eq({:test=>"val"})
+  end
 end


### PR DESCRIPTION
This brings its API more in line with Chef::Mash and exposes a method we
can use in Chef Provisioning (which uses internal symbols everywhere)

