### PR TITLE
remove Chef::Mash

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -3,8 +3,8 @@ require "chef/mash"
 module Cheffish
   class MergedConfig
     def initialize(*configs)
-      @configs = configs.map { |config| Chef::Mash.from_hash config }
-      @merge_arrays = Chef::Mash.new
+      @configs = configs.map { |config| Mash.from_hash config }
+      @merge_arrays = Mash.new
     end
 
     include Enumerable


### PR DESCRIPTION
its just "Mash", necessary for ruby 2.5.0

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>