### PR TITLE
deprecate method_missing in cheffish merged_config

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -48,6 +48,7 @@ module Cheffish
     end
 
     def method_missing(name, *args)
+      $stderr.puts "WARN: deprecated use of method_missing on a Cheffish::MergedConfig object"
       if args.count > 0
         raise NoMethodError, "Unexpected method #{name} for MergedConfig with arguments #{args}"
       else

--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -48,7 +48,7 @@ module Cheffish
     end
 
     def method_missing(name, *args)
-      $stderr.puts "WARN: deprecated use of method_missing on a Cheffish::MergedConfig object"
+      $stderr.puts "WARN: deprecated use of method_missing on a Cheffish::MergedConfig object at #{caller[0]}"
       if args.count > 0
         raise NoMethodError, "Unexpected method #{name} for MergedConfig with arguments #{args}"
       else


### PR DESCRIPTION
typical "method_missing is terrible" reasons...