### PR TITLE
fix nested merge configs

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -3,7 +3,7 @@ require "chef/mash"
 module Cheffish
   class MergedConfig
     def initialize(*configs)
-      @configs = configs.map { |config| Mash.from_hash config }
+      @configs = configs.map { |config| Mash.from_hash config.to_hash }
       @merge_arrays = Mash.new
     end
 

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -24,6 +24,13 @@ describe "merged_config" do
     Cheffish::MergedConfig.new(c1, c2)
   end
 
+  let(:nested_config) do
+    c1 = { :test => { :test => "val" } }
+    c2 = { :test => { :test2 => "val2" } }
+    mc = Cheffish::MergedConfig.new(c2)
+    Cheffish::MergedConfig.new(c1, mc)
+  end
+
   it "returns value in config" do
     expect(config.test).to eq("val")
   end
@@ -56,5 +63,9 @@ describe "merged_config" do
 
   it "merges values when they're hashes" do
     expect(config_hashes[:test].keys).to eq(%w{test test2})
+  end
+
+  it "supports nested merged configs" do
+    expect(nested_config[:test].keys).to eq(%w{test test2})
   end
 end


### PR DESCRIPTION
chef-provisioning-fog uses this feature and the switch to Mash objects
broke it -- because Chef::Mash.from_hash doesn't know how to coerce a
MergedConfig object into a Hash first.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>