### PR TITLE
Add empty? to Cheffish::MergedConfig

### DIFF
--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -70,6 +70,10 @@ module Cheffish
       keys.map { |key| self[key] }
     end
 
+    def empty?
+      configs.empty?
+    end
+
     def each_pair(&block)
       each(&block)
     end

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -31,6 +31,10 @@ describe "merged_config" do
     Cheffish::MergedConfig.new(c1, mc)
   end
 
+  let(:empty_config) do
+    Cheffish::MergedConfig.new
+  end
+
   it "returns value in config" do
     expect(config.test).to eq("val")
   end
@@ -67,5 +71,10 @@ describe "merged_config" do
 
   it "supports nested merged configs" do
     expect(nested_config[:test].keys).to eq(%w{test test2})
+  end
+
+  it "supports empty?" do
+    expect(empty_config.empty?).to eq true
+    expect(nested_config.empty?).to eq false
   end
 end


### PR DESCRIPTION
`chef-provisioning-vsphere` is warning about using `empty?` on Cheffish::MergedConfig.

```
WARN: deprecated use of method_missing on a Cheffish::MergedConfig object at ...../.chefdk/gem/ruby/2.4.0/gems/chef-provisioning-vsphere-2.1.0/lib/chef/provisioning/vsphere_driver/driver.rb:59:in `deep_symbolize'
```

I think others may have the deprecation warning for using the same method.

Signed-off-by: Josh Barker <josh.barker.developer@gmail.com>