### PR TITLE
private_key: Fix cipher comparison to ignore case

### DIFF
--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -31,7 +31,7 @@ class Chef
 
       # PEM-only
       property :pass_phrase, String
-      property :cipher, OpenSSL::Cipher.ciphers, default: "DES-EDE3-CBC"
+      property :cipher, String, equal_to: OpenSSL::Cipher.ciphers.map { |x| x.downcase }, default: "des-ede3-cbc", coerce: proc { |x| x.downcase }
 
       # Set this to regenerate the key if it does not have the desired characteristics (like size, type, etc.)
       property :regenerate_if_different, Boolean


### PR DESCRIPTION
It turns out that different releases of Ruby and openssl present the ciphers differently and according to the Ruby docs the case doesn't matter. Lets downcase the available ciphers and what they user provides so we can properly compare them.

Signed-off-by: Tim Smith <tsmith@chef.io>