### PR TITLE
Don't eval the action_class

### DIFF
--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -75,7 +75,7 @@ class Chef
         end
       end
 
-      action_class.class_eval do
+      action_class do
         # Update the ACL if necessary.
         def create_acl(path)
           changed = false

--- a/lib/chef/resource/chef_client.rb
+++ b/lib/chef/resource/chef_client.rb
@@ -38,7 +38,7 @@ class Chef
         delete_actor
       end
 
-      action_class.class_eval do
+      action_class do
         def actor_type
           "client"
         end

--- a/lib/chef/resource/chef_container.rb
+++ b/lib/chef/resource/chef_container.rb
@@ -25,7 +25,7 @@ class Chef
         end
       end
 
-      action_class.class_eval do
+      action_class do
         def load_current_resource
           @current_exists = rest.get("containers/#{new_resource.chef_container_name}")
         rescue Net::HTTPServerException => e


### PR DESCRIPTION
This shouldn't be necessarily in any supported Chef release.

Signed-off-by: Tim Smith <tsmith@chef.io>