### PR TITLE
Replace HTTPServerException with HTTPClientException

### DIFF
--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -147,7 +147,7 @@ class Chef
           unless @current_acls.key?(acl_path)
             @current_acls[acl_path] = begin
               rest.get(rest_url(acl_path))
-                                      rescue Net::HTTPServerException => e
+                                      rescue Net::HTTPClientException => e
                                         unless e.response.code == "404" && new_resource.path.split("/").any? { |p| p == "*" }
                                           raise
                                         end
@@ -471,7 +471,7 @@ class Chef
         def rest_list(path)
           # All our rest lists are hashes where the keys are the names
           [ rest.get(rest_url(path)).keys, nil ]
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "405" || e.response.code == "404"
             parts = path.split("/").select { |p| p != "" }.to_a
 

--- a/lib/chef/resource/chef_container.rb
+++ b/lib/chef/resource/chef_container.rb
@@ -28,7 +28,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_exists = rest.get("containers/#{new_resource.chef_container_name}")
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_exists = false
           else

--- a/lib/chef/resource/chef_data_bag.rb
+++ b/lib/chef/resource/chef_data_bag.rb
@@ -27,7 +27,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("data/#{new_resource.data_bag_name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/chef/resource/chef_data_bag_item.rb
+++ b/lib/chef/resource/chef_data_bag_item.rb
@@ -103,7 +103,7 @@ class Chef
             resource = Chef::Resource::ChefDataBagItem.new(new_resource.name, run_context)
             resource.raw_data json
             @current_resource = resource
-          rescue Net::HTTPServerException => e
+          rescue Net::HTTPClientException => e
             if e.response.code == "404"
               @current_resource = not_found_resource
             else

--- a/lib/chef/resource/chef_environment.rb
+++ b/lib/chef/resource/chef_environment.rb
@@ -84,7 +84,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("environments/#{new_resource.environment_name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/chef/resource/chef_group.rb
+++ b/lib/chef/resource/chef_group.rb
@@ -45,7 +45,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("groups/#{new_resource.group_name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/chef/resource/chef_node.rb
+++ b/lib/chef/resource/chef_node.rb
@@ -39,7 +39,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("nodes/#{new_resource.name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/chef/resource/chef_organization.rb
+++ b/lib/chef/resource/chef_organization.rb
@@ -130,7 +130,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("#{rest.root_url}/organizations/#{new_resource.organization_name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/chef/resource/chef_role.rb
+++ b/lib/chef/resource/chef_role.rb
@@ -123,7 +123,7 @@ class Chef
       action_class.class_eval do
         def load_current_resource
           @current_resource = json_to_resource(rest.get("roles/#{new_resource.role_name}"))
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/lib/cheffish/chef_actor_base.rb
+++ b/lib/cheffish/chef_actor_base.rb
@@ -119,7 +119,7 @@ module Cheffish
         begin
           json = rest.get("#{actor_path}/#{new_resource.name}")
           @current_resource = json_to_resource(json)
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           if e.response.code == "404"
             @current_resource = not_found_resource
           else

--- a/spec/integration/chef_acl_spec.rb
+++ b/spec/integration/chef_acl_spec.rb
@@ -191,7 +191,7 @@ if Gem::Version.new(ChefZero::VERSION) >= Gem::Version.new("3.1")
         it 'Converging chef_acl "nodes/y" throws a 404' do
           expect_converge do
             chef_acl "nodes/y"
-          end.to raise_error(Net::HTTPServerException)
+          end.to raise_error(Net::HTTPClientException)
         end
       end
 

--- a/spec/integration/chef_group_spec.rb
+++ b/spec/integration/chef_group_spec.rb
@@ -37,7 +37,7 @@ describe Chef::Resource::ChefGroup do
             action :delete
           end
         end.to not_have_updated("chef_group[x]", :delete).and not_have_updated("chef_group[x]", :create)
-        expect { get("groups/x") }.to raise_error(Net::HTTPServerException)
+        expect { get("groups/x") }.to raise_error(Net::HTTPClientException)
       end
 
       it 'Converging chef_group "x" creates the group with the given members' do
@@ -101,7 +101,7 @@ describe Chef::Resource::ChefGroup do
             action :delete
           end
         end.to have_updated("chef_group[x]", :delete)
-        expect { get("groups/x") }.to raise_error(Net::HTTPServerException)
+        expect { get("groups/x") }.to raise_error(Net::HTTPClientException)
       end
 
       it 'Converging chef_group "x" with existing users changes nothing' do

--- a/spec/integration/chef_node_spec.rb
+++ b/spec/integration/chef_node_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Resource::ChefNode do
               with_chef_server "http://127.0.0.1:8899"
               chef_node "blah"
             end.to have_updated "chef_node[blah]", :create
-            expect { get("nodes/blah") }.to raise_error(Net::HTTPServerException)
+            expect { get("nodes/blah") }.to raise_error(Net::HTTPClientException)
             expect(get("http://127.0.0.1:8899/nodes/blah")["name"]).to eq("blah")
           end
         end
@@ -53,7 +53,7 @@ describe Chef::Resource::ChefNode do
                 chef_server({ chef_server_url: "http://127.0.0.1:8899" })
               end
             end.to have_updated "chef_node[blah]", :create
-            expect { get("nodes/blah") }.to raise_error(Net::HTTPServerException)
+            expect { get("nodes/blah") }.to raise_error(Net::HTTPClientException)
             expect(get("http://127.0.0.1:8899/nodes/blah")["name"]).to eq("blah")
           end
         end

--- a/spec/integration/chef_role_spec.rb
+++ b/spec/integration/chef_role_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Resource::ChefRole do
               with_chef_server "http://127.0.0.1:8899"
               chef_role "blah"
             end.to have_updated "chef_role[blah]", :create
-            expect { get("roles/blah") }.to raise_error(Net::HTTPServerException)
+            expect { get("roles/blah") }.to raise_error(Net::HTTPClientException)
             expect(get("http://127.0.0.1:8899/roles/blah")["name"]).to eq("blah")
           end
         end
@@ -53,7 +53,7 @@ describe Chef::Resource::ChefRole do
                 chef_server({ chef_server_url: "http://127.0.0.1:8899" })
               end
             end.to have_updated "chef_role[blah]", :create
-            expect { get("roles/blah") }.to raise_error(Net::HTTPServerException)
+            expect { get("roles/blah") }.to raise_error(Net::HTTPClientException)
             expect(get("http://127.0.0.1:8899/roles/blah")["name"]).to eq("blah")
           end
         end


### PR DESCRIPTION
Avoid deprecation warnings when using Cheffish

Fixes #157 

Signed-off-by: Tim Smith <tsmith@chef.io>