### PR TITLE
Remove support for PKCS8 SHA1 fingerprints

### DIFF
--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -469,7 +469,7 @@ class Chef
         end
 
         def rest_list(path)
-            # All our rest lists are hashes where the keys are the names
+          # All our rest lists are hashes where the keys are the names
           [ rest.get(rest_url(path)).keys, nil ]
         rescue Net::HTTPServerException => e
           if e.response.code == "405" || e.response.code == "404"

--- a/lib/cheffish/key_formatter.rb
+++ b/lib/cheffish/key_formatter.rb
@@ -55,16 +55,7 @@ module Cheffish
         hexes = Digest::MD5.hexdigest(data)
         hexes.scan(/../).join(":")
       when :pkcs8sha1fingerprint
-        if RUBY_VERSION.to_f >= 2.0
-          raise "PKCS8 SHA1 not supported in Ruby #{RUBY_VERSION}"
-        end
-
-        require "openssl_pkcs8"
-        pkcs8_pem = key.to_pem_pkcs8
-        pkcs8_base64 = pkcs8_pem.split("\n").reject { |l| l =~ /^-----/ }
-        pkcs8_data = Base64.decode64(pkcs8_base64.join)
-        hexes = Digest::SHA1.hexdigest(pkcs8_data)
-        hexes.scan(/../).join(":")
+        raise "PKCS8 SHA1 not supported by Ruby 2.0 and later"
       else
         raise "Unrecognized key format #{format}"
       end

--- a/spec/functional/fingerprint_spec.rb
+++ b/spec/functional/fingerprint_spec.rb
@@ -39,10 +39,8 @@ describe "Cheffish fingerprint key formatter" do
 
   context "when computing key fingperprints" do
 
-    it "computes the PKCS#8 SHA1 private key fingerprint correctly", pending: (RUBY_VERSION.to_f >= 2.0) do
-      expect(key_to_format(sample_private_key, :pkcs8sha1fingerprint)).to eq(
-        "88:7e:3a:bd:26:9f:b5:c5:d8:ae:52:f9:df:0b:64:a4:5c:17:0a:87"
-      )
+    it "raises when passing a PKCS#8 SHA1 private key fingerprint" do
+      expect { key_to_format(sample_private_key, :pkcs8sha1fingerprint) }.to raise_error
     end
 
     it "computes the PKCS#1 MD5 public key fingerprint correctly" do


### PR DESCRIPTION
This only worked on Ruby < 2. Instead of gating that and having tests
that blow up we should just remove all the supporting code since it'll
never work.

Signed-off-by: Tim Smith <tsmith@chef.io>