### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/chef/resource/chef_acl.rb
+++ b/lib/chef/resource/chef_acl.rb
@@ -2,7 +2,7 @@ require_relative "../../cheffish"
 require_relative "../../cheffish/base_resource"
 require "chef/chef_fs/data_handler/acl_data_handler"
 require "chef/chef_fs/parallelizer"
-require "uri"
+require "uri" unless defined?(URI)
 
 class Chef
   class Resource

--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -1,6 +1,6 @@
 require "openssl/cipher"
 require_relative "../../cheffish/base_resource"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require_relative "../../cheffish/key_formatter"
 
 class Chef

--- a/lib/chef/resource/public_key.rb
+++ b/lib/chef/resource/public_key.rb
@@ -1,6 +1,6 @@
 require "openssl/cipher"
 require_relative "../../cheffish/base_resource"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require_relative "../../cheffish/key_formatter"
 
 class Chef

--- a/lib/cheffish/basic_chef_client.rb
+++ b/lib/cheffish/basic_chef_client.rb
@@ -5,7 +5,7 @@ require "chef/event_dispatch/dispatcher"
 require "chef/node"
 require "chef/run_context"
 require "chef/runner"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require "chef/providers"
 require "chef/resources"
 

--- a/lib/cheffish/key_formatter.rb
+++ b/lib/cheffish/key_formatter.rb
@@ -1,7 +1,7 @@
-require "openssl"
-require "net/ssh"
-require "etc"
-require "socket"
+require "openssl" unless defined?(OpenSSL)
+require "net/ssh" unless defined?(Net::SSH)
+require "etc" unless defined?(Etc)
+require "socket" unless defined?(Socket)
 require "digest/md5"
 require "base64"
 

--- a/lib/cheffish/rspec/chef_run_support.rb
+++ b/lib/cheffish/rspec/chef_run_support.rb
@@ -1,7 +1,7 @@
 require "chef_zero/rspec"
 require "chef/server_api"
 require_relative "repository_support"
-require "uri"
+require "uri" unless defined?(URI)
 require_relative "../chef_run"
 require_relative "recipe_run_wrapper"
 require_relative "matchers"

--- a/lib/cheffish/rspec/recipe_run_wrapper.rb
+++ b/lib/cheffish/rspec/recipe_run_wrapper.rb
@@ -1,5 +1,5 @@
 require_relative "../chef_run"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 module Cheffish
   module RSpec


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>