### PR TITLE
Fixes for Chef-17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,20 @@ group :development do
   gem "rspec", "~> 3.0"
 end
 
+# temporarily we only support building against master
+gem "chef", github: "chef/chef", branch: "master"
+gem "ohai", github: "chef/ohai", branch: "master"
+
 # Allow Travis to run tests with different dependency versions
-if ENV["GEMFILE_MOD"]
-  puts ENV["GEMFILE_MOD"]
-  instance_eval(ENV["GEMFILE_MOD"])
-else
-  group :development do
-    gem "chef", "~> 16"
-    gem "ohai", "~> 16"
-  end
-end
+# if ENV["GEMFILE_MOD"]
+#   puts ENV["GEMFILE_MOD"]
+#   instance_eval(ENV["GEMFILE_MOD"])
+# else
+#   group :development do
+#     gem "chef", "~> 16"
+#     gem "ohai", "~> 16"
+#   end
+# end
 
 group :docs do
   gem "yard"

--- a/Rakefile
+++ b/Rakefile
@@ -39,4 +39,4 @@ task :console do
   IRB.start
 end
 
-task default: %i{style spec}
+task default: %i{spec style}

--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6.0"
 
   s.add_dependency "chef-zero", ">= 14.0"
+  s.add_dependency "chef-utils", ">= 17.0"
   s.add_dependency "net-ssh"
 
   s.bindir       = "bin"

--- a/lib/chef/resource/chef_mirror.rb
+++ b/lib/chef/resource/chef_mirror.rb
@@ -2,9 +2,11 @@ require_relative "../../cheffish"
 require_relative "../../cheffish/base_resource"
 require "chef/chef_fs/file_pattern"
 require "chef/chef_fs/file_system"
-require "chef/chef_fs/parallelizer"
 require "chef/chef_fs/file_system/chef_server/chef_server_root_dir"
 require "chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir"
+require "chef-utils/parallel_map" unless defined?(ChefUtils::ParallelMap)
+
+using ChefUtils::ParallelMap
 
 class Chef
   class Resource
@@ -97,7 +99,7 @@ class Chef
           end
 
           # Honor concurrency
-          Chef::ChefFS::Parallelizer.threads = new_resource.concurrency - 1
+          ChefUtils::DefaultThreadPool.instance.threads = new_resource.concurrency - 1
 
           # We don't let the user pass absolute paths; we want to reserve those for
           # multi-org support (/organizations/foo).


### PR DESCRIPTION
Updates for the removal of the chef-fs parallelizer.

This will be totally broken until we merge that PR into
chef-client itself, this is necessary to get that PR
green though and testing will continue there.

This drops support for chef <= 16, future versions of
cheffish will likely be brought into the chef-client
repo itself
