### PR TITLE
Use `identity` instead of `name`

### DIFF
--- a/lib/cheffish/base_resource.rb
+++ b/lib/cheffish/base_resource.rb
@@ -15,7 +15,7 @@ module Cheffish
       end
 
       def not_found_resource
-        resource = resource_class.new(new_resource.name, run_context)
+        resource = resource_class.new(new_resource.identity, run_context)
         resource.action :delete
         resource
       end
@@ -71,7 +71,7 @@ module Cheffish
       end
 
       def json_to_resource(json)
-        resource = resource_class.new(new_resource.name, run_context)
+        resource = resource_class.new(new_resource.identity, run_context)
         keys.each do |json_key, resource_key|
           resource.send(resource_key, json.delete(json_key))
         end

--- a/lib/cheffish/chef_actor_base.rb
+++ b/lib/cheffish/chef_actor_base.rb
@@ -16,9 +16,9 @@ module Cheffish
         if current_resource_exists?
           # Update the actor if it's different
           if differences.size > 0
-            description = [ "update #{actor_type} #{new_resource.name} at #{actor_path}" ] + differences
+            description = [ "update #{actor_type} #{new_resource.identity} at #{actor_path}" ] + differences
             converge_by description do
-              result = rest.put("#{actor_path}/#{new_resource.name}", normalize_for_put(new_json))
+              result = rest.put("#{actor_path}/#{new_resource.identity}", normalize_for_put(new_json))
               current_public_key, _current_public_key_format = Cheffish::KeyFormatter.decode(result["public_key"]) if result["public_key"]
             end
           end
@@ -28,7 +28,7 @@ module Cheffish
             raise "You must specify a public key to create a #{actor_type}!  Use the private_key resource to create a key, and pass it in with source_key_path."
           end
 
-          description = [ "create #{actor_type} #{new_resource.name} at #{actor_path}" ] + differences
+          description = [ "create #{actor_type} #{new_resource.identity} at #{actor_path}" ] + differences
           converge_by description do
             result = rest.post((actor_path).to_s, normalize_for_post(new_json))
             current_public_key, _current_public_key_format = Cheffish::KeyFormatter.decode(result["public_key"]) if result["public_key"]
@@ -61,9 +61,9 @@ module Cheffish
 
       def delete_actor
         if current_resource_exists?
-          converge_by "delete #{actor_type} #{new_resource.name} at #{actor_path}" do
-            rest.delete("#{actor_path}/#{new_resource.name}")
-            Chef::Log.info("#{new_resource} deleted #{actor_type} #{new_resource.name} at #{rest.url}")
+          converge_by "delete #{actor_type} #{new_resource.identity} at #{actor_path}" do
+            rest.delete("#{actor_path}/#{new_resource.identity}")
+            Chef::Log.info("#{new_resource} deleted #{actor_type} #{new_resource.identity} at #{rest.url}")
           end
         end
         if current_resource.output_key_path
@@ -115,7 +115,7 @@ module Cheffish
 
       def load_current_resource
         begin
-          json = rest.get("#{actor_path}/#{new_resource.name}")
+          json = rest.get("#{actor_path}/#{new_resource.identity}")
           @current_resource = json_to_resource(json)
         rescue Net::HTTPClientException => e
           if e.response.code == "404"


### PR DESCRIPTION
  
Signed-off-by: joe.nuspl <nuspl@nvwls.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Since `name` must be unique, patterns such as:

```
chef_client "bob in #{org}" do
  chef_client_name 'bob'
end
```

are used.  `chef_client` and `chef_user` both inherit from Cheffish::ChefActorBase. Using `identity` instead of `name` allows ChefActorBase to remain generic.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
