### PR TITLE
Remove testing on Ruby 2.6

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,15 +16,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-buster
-
-- label: run-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
+        image: ruby:2.7-buster
 
 - label: run-specs-ruby-2.7
   command:

--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -12,14 +12,11 @@ Gem::Specification.new do |s|
   s.email = "oss@chef.io"
   s.homepage = "https://github.com/chef/cheffish"
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "chef-zero", ">= 14.0"
   s.add_dependency "chef-utils", ">= 17.0"
   s.add_dependency "net-ssh"
-
-  s.bindir       = "bin"
-  s.executables  = %w{ }
 
   s.require_path = "lib"
   s.files = %w{Gemfile Rakefile LICENSE} + Dir.glob("*.gemspec") +


### PR DESCRIPTION
We don't support Ruby 2.6 anymore

Signed-off-by: Tim Smith <tsmith@chef.io>