### PR TITLE
Require Ruby 3.0 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,14 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rspec
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
-
 - label: run-specs-ruby-3.0
   command:
     - .expeditor/run_linux_tests.sh rspec

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: '3.0'
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - run: bundle exec rake style

--- a/Gemfile
+++ b/Gemfile
@@ -17,20 +17,5 @@ else
     # temporarily we only support building against master
     gem "chef", github: "chef/chef", branch: "master"
     gem "ohai", github: "chef/ohai", branch: "master"
-    # gem "chef", "~> 16"
-    # gem "ohai", "~> 16"
   end
-end
-
-group :docs do
-  gem "yard"
-  gem "redcarpet"
-  gem "github-markup"
-end
-
-group :debug do
-  gem "pry"
-  gem "pry-byebug"
-  gem "pry-stack_explorer"
-  gem "rb-readline"
 end

--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "oss@chef.io"
   s.homepage = "https://github.com/chef/cheffish"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "chef-zero", ">= 14.0"
   s.add_dependency "chef-utils", ">= 17.0"


### PR DESCRIPTION
Version 17.x is actually broken on Ruby < 3 due to a regression in Ruby
that they've chosen not to fix in the 2.x releases. We can't support
both Ruby 3 and 2.x so 2.x has to go.

Signed-off-by: Tim Smith <tsmith@chef.io>