### PR TITLE
Tweaking for Ruby 3.4.2

### DIFF
--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['3.0', '3.1']
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes
+        ruby: ['3.1', '3.4']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -1,7 +1,7 @@
 ---
 name: unit_specs
 
-"on":
+on:
   pull_request:
   push:
     branches:

--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,12 @@ else
       gem "chef", "~> 17.0"
       gem "ohai", "~> 17.0"
     when /^3\.1/
+      # Ruby 3.1+ should use Chef 18 for now until Chef 19 gem is released
       gem "chef", "~> 18.0"
       gem "ohai", "~> 18.0"
     else
       # go with the latest, unbounded
+      gem "chef-utils", git: "https://github.com/chef/chef.git", glob: "chef-utils/*.gemspec"
       gem "chef", git: "https://github.com/chef/chef.git"
       gem "ohai", git: "https://github.com/chef/ohai.git"
     end

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ else
       gem "ohai", "~> 18.0"
     else
       # go with the latest, unbounded
-      gem "chef"
-      gem "ohai"
+      gem "chef", git: "https://github.com/chef/chef.git"
+      gem "ohai", git: "https://github.com/chef/ohai.git"
     end
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :style do
-  gem "cookstyle", "~> 8.2"
+  gem "cookstyle", "~> 8.4"
 end
 
 # Allow Travis to run tests with different dependency versions

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development do
-  gem "cookstyle", "~> 7.32.8"
-  gem "rake"
-  gem "rspec", "~> 3.0"
+group :style do
+  gem "cookstyle", "~> 8.2"
 end
 
 # Allow Travis to run tests with different dependency versions
@@ -14,6 +12,8 @@ if ENV["GEMFILE_MOD"]
   instance_eval(ENV["GEMFILE_MOD"])
 else
   group :development do
+    gem "rake"
+    gem "rspec", "~> 3.0"
     # chef 17 is on 3.0
     # chef 18 is on 3.1
     case RUBY_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -13,15 +13,20 @@ rescue LoadError
   end
 end
 
-begin
-  require "cookstyle/chefstyle"
+desc "Check Linting and code style."
+task :style do
   require "rubocop/rake_task"
-  desc "Run Chefstyle tests"
-  RuboCop::RakeTask.new(:style) do |task|
-    task.options += ["--display-cop-names", "--no-color"]
+  require "cookstyle/chefstyle"
+
+  if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+    # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaeded to GitHub.
+    # This is a workaround to ignore the CRLF from the files before running cookstyle.
+    sh "cookstyle --chefstyle -c .rubocop.yml --except Layout/EndOfLine"
+  else
+    sh "cookstyle --chefstyle -c .rubocop.yml"
   end
 rescue LoadError
-  puts "cookstyle gem is not installed. bundle install first to make sure all dependencies are installed."
+  puts "Rubocop or Cookstyle gems are not installed. bundle install first to make sure all dependencies are installed."
 end
 
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,17 @@ rescue LoadError
   end
 end
 
+def require_gem(gem_name)
+  require gem_name
+rescue LoadError
+  puts "#{gem_name} gem is not installed. Please run 'bundle install' first to make sure all dependencies are installed."
+  exit 1
+end
+
 desc "Check Linting and code style."
 task :style do
-  require "rubocop/rake_task"
-  require "cookstyle/chefstyle"
+  require_gem "rubocop/rake_task"
+  require_gem "cookstyle/chefstyle"
 
   if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
     # Windows-specific command, rubocop erroneously reports the CRLF in each file which is removed when your PR is uploaeded to GitHub.
@@ -25,8 +32,6 @@ task :style do
   else
     sh "cookstyle --chefstyle -c .rubocop.yml"
   end
-rescue LoadError
-  puts "Rubocop or Cookstyle gems are not installed. bundle install first to make sure all dependencies are installed."
 end
 
 begin

--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "oss@chef.io"
   s.homepage = "https://github.com/chef/cheffish"
 
-  s.required_ruby_version = ">= 3.0"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency "chef-zero", ">= 14.0"
   s.add_dependency "chef-utils", ">= 17.0"

--- a/cheffish.gemspec
+++ b/cheffish.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-utils", ">= 17.0"
   s.add_dependency "logger", "< 1.6.0"
   s.add_dependency "net-ssh"
+  s.add_dependency "syslog"
 
   s.require_path = "lib"
   s.files = %w{Gemfile Rakefile LICENSE} + Dir.glob("*.gemspec") +

--- a/lib/chef/resource/chef_mirror.rb
+++ b/lib/chef/resource/chef_mirror.rb
@@ -110,7 +110,7 @@ class Chef
           # Copy!
           path = Chef::ChefFS::FilePattern.new("/#{new_resource.path}")
           ui = CopyListener.new(self)
-          error, _result = Chef::ChefFS::FileSystem.copy_to(path, src_root, dest_root, nil, options, ui, proc { |p| p.path })
+          error, _result = Chef::ChefFS::FileSystem.copy_to(path, src_root, dest_root, nil, options, ui, proc(&:path))
 
           if error
             raise "Errors while copying:#{ui.errors.map { |e| "#{e}\n" }.join("")}"

--- a/lib/chef/resource/private_key.rb
+++ b/lib/chef/resource/private_key.rb
@@ -31,7 +31,7 @@ class Chef
 
       # PEM-only
       property :pass_phrase, String
-      property :cipher, String, equal_to: OpenSSL::Cipher.ciphers.map(&:downcase), default: "des-ede3-cbc", coerce: proc { |x| x.downcase }
+      property :cipher, String, equal_to: OpenSSL::Cipher.ciphers.map(&:downcase), default: "des-ede3-cbc", coerce: proc(&:downcase)
 
       # Set this to regenerate the key if it does not have the desired characteristics (like size, type, etc.)
       property :regenerate_if_different, [TrueClass, FalseClass]

--- a/lib/cheffish/merged_config.rb
+++ b/lib/cheffish/merged_config.rb
@@ -49,7 +49,7 @@ module Cheffish
 
     def method_missing(name, *args)
       $stderr.puts "WARN: deprecated use of method_missing on a Cheffish::MergedConfig object at #{caller[0]}"
-      if args.count > 0
+      if args.any?
         raise NoMethodError, "Unexpected method #{name} for MergedConfig with arguments #{args}"
       else
         self[name]

--- a/lib/cheffish/rspec/chef_run_support.rb
+++ b/lib/cheffish/rspec/chef_run_support.rb
@@ -1,5 +1,5 @@
 require "chef_zero/rspec"
-require "chef/server_api"
+require_relative "../server_api"
 require_relative "repository_support"
 require "uri" unless defined?(URI)
 require_relative "../chef_run"

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -44,7 +44,7 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect(config.to_hash).to eq({"test" => "val"})
+    expect(config.to_hash).to eq({ "test" => "val" })
   end
 
   it "has indifferent str/sym access" do

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -44,7 +44,7 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect(config.to_hash.inspect).to eq("{\"test\"=>\"val\"}")
+    expect(config.to_hash).to eq({"test" => "val"})
   end
 
   it "has indifferent str/sym access" do

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -44,7 +44,7 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect((config).to_s).to eq("{\"test\" => \"val\"}")
+    expect((config).to_s).to eq("{\"test\"=>\"val\"}")
   end
 
   it "has indifferent str/sym access" do

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -44,7 +44,7 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect((config).to_s).to eq("{\"test\"=>\"val\"}")
+    expect((config).to_s).to eq("{\"test\" => \"val\"}")
   end
 
   it "has indifferent str/sym access" do

--- a/spec/functional/merged_config_spec.rb
+++ b/spec/functional/merged_config_spec.rb
@@ -44,7 +44,7 @@ describe "merged_config" do
   end
 
   it "has an informative string representation" do
-    expect((config).to_s).to eq("{\"test\"=>\"val\"}")
+    expect(config.to_hash.inspect).to eq("{\"test\"=>\"val\"}")
   end
 
   it "has indifferent str/sym access" do

--- a/spec/integration/chef_acl_spec.rb
+++ b/spec/integration/chef_acl_spec.rb
@@ -216,10 +216,10 @@ if Gem::Version.new(ChefZero::VERSION) >= Gem::Version.new("3.1")
         user "bar", {}
         node "x", {} do
           acl "create" => { "actors" => %w{foo bar} },
-              "read" => { "actors" => %w{foo bar} },
-              "update" => { "actors" => %w{foo bar} },
-              "delete" => { "actors" => %w{foo bar} },
-              "grant" => { "actors" => %w{foo bar} }
+            "read" => { "actors" => %w{foo bar} },
+            "update" => { "actors" => %w{foo bar} },
+            "delete" => { "actors" => %w{foo bar} },
+            "grant" => { "actors" => %w{foo bar} }
         end
 
         it 'Converging chef_acl "nodes/x" with remove_rights :all removes foo from everything' do
@@ -792,8 +792,8 @@ if Gem::Version.new(ChefZero::VERSION) >= Gem::Version.new("3.1")
         group "g2", {}
         node "x", {} do
           acl "create" => { "actors" => %w{u c}, "groups" => [ "g" ] },
-              "read"   => { "actors" => %w{u c}, "groups" => [ "g" ] },
-              "update" => { "actors" => %w{u c}, "groups" => [ "g" ] }
+            "read"   => { "actors" => %w{u c}, "groups" => [ "g" ] },
+            "update" => { "actors" => %w{u c}, "groups" => [ "g" ] }
         end
 
         it 'chef_acl with remove_rights "u" removes the user\'s rights' do

--- a/spec/integration/chef_mirror_spec.rb
+++ b/spec/integration/chef_mirror_spec.rb
@@ -184,8 +184,8 @@ describe Chef::Resource::ChefMirror do
           expect_recipe do
             chef_mirror "" do
               chef_repo_path chef_repo_path: "/blahblah",
-                             node_path: "#{repo_path}/nodes",
-                             role_path: "#{repo2_path}/roles"
+                node_path: "#{repo_path}/nodes",
+                role_path: "#{repo2_path}/roles"
               action :upload
             end
           end.to have_updated("chef_mirror[]", :upload)
@@ -202,7 +202,7 @@ describe Chef::Resource::ChefMirror do
           expect_recipe do
             chef_mirror "" do
               chef_repo_path chef_repo_path: repo_path,
-                             role_path: "#{repo2_path}/roles"
+                role_path: "#{repo2_path}/roles"
               action :upload
             end
           end.to have_updated("chef_mirror[]", :upload)
@@ -219,8 +219,8 @@ describe Chef::Resource::ChefMirror do
           expect_recipe do
             chef_mirror "" do
               chef_repo_path chef_repo_path: %w{foo bar},
-                             node_path: [ "#{repo_path}/nodes", "#{repo2_path}/nodes" ],
-                             role_path: [ "#{repo_path}/roles", "#{repo2_path}/roles" ]
+                node_path: [ "#{repo_path}/nodes", "#{repo2_path}/nodes" ],
+                role_path: [ "#{repo_path}/roles", "#{repo2_path}/roles" ]
               action :upload
             end
           end.to have_updated("chef_mirror[]", :upload)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In building Chef-19 RC3, we found some issues in the verify pipeline related to Ruby 3.4 syntax changes. We also needed to update the gemfile here too. 

Some of the tests were failing when calling the server_api. 
Summary
The issue was caused by an incorrect [require](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) statement in [chef_run_support.rb](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Problem:

Line 2 had [require "chef/server_api"](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
But there is no [server_api.rb](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file in the project
The actual file is [server_api.rb](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Solution:

Changed [require "chef/server_api"](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [require_relative "../server_api"](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
This correctly points to the [server_api.rb](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file in the parent cheffish directory
The fix resolves the LoadError: cannot load such file -- chef/server_api error that external testers were encountering. The test now runs successfully, as demonstrated by the RSpec output showing "1 example, 0 failures".

There is version detection code that installs a version of chef based on the Ruby version. At the bottom of that block we are pulling directly from the chef repo on github for unreleased versions of chef-19. That might need to be adjust in the future based on needs then.

Finally, per feedback, I added a custom method to load cookstyle and rubocop classes that would call out which one was a problem if either errored out during loading. Previously, the code block was capturing a generic load error if either of them had an issue

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
